### PR TITLE
Remove rpc scope from types

### DIFF
--- a/examples/iframe-playground/packages/client/src/actions/authActions.ts
+++ b/examples/iframe-playground/packages/client/src/actions/authActions.ts
@@ -12,6 +12,32 @@ export const start = async () => {
 
   await discordSdk.ready();
 
+  const scope: Types.OAuthScopes[] = [
+    // "applications.builds.upload",
+    // "applications.builds.read",
+    // "applications.store.update",
+    // "applications.entitlements",
+    // "bot",
+    'identify',
+    // "connections",
+    // "email",
+    // "gdm.join",
+    'guilds',
+    // "guilds.join",
+    'guilds.members.read',
+    // "messages.read",
+    // "relationships.read",
+    // 'rpc.activities.write',
+    // "rpc.notifications.read",
+    'rpc.voice.write',
+    'rpc.voice.read',
+    // "webhook.incoming",
+  ];
+
+  if (discordSdk.guildId == null) {
+    scope.push('dm_channels.read');
+  }
+
   // Authorize with Discord Client
   const {code} = await discordSdk.commands.authorize({
     client_id: import.meta.env.VITE_CLIENT_ID,
@@ -19,28 +45,7 @@ export const start = async () => {
     state: '',
     prompt: 'none',
     // More info on scopes here: https://discord.com/developers/docs/topics/oauth2#shared-resources-oauth2-scopes
-    scope: [
-      // "applications.builds.upload",
-      // "applications.builds.read",
-      // "applications.store.update",
-      // "applications.entitlements",
-      // "bot",
-      'identify',
-      // "connections",
-      // "email",
-      // "gdm.join",
-      'guilds',
-      // "guilds.join",
-      'guilds.members.read',
-      // "messages.read",
-      // "relationships.read",
-      // 'rpc.activities.write',
-      // "rpc.notifications.read",
-      'rpc.voice.write',
-      'rpc.voice.read',
-      // "webhook.incoming",
-      discordSdk.guildId == null ? 'dm_channels.read' : null, // This scope requires approval from Discord.
-    ].filter((scope) => scope != null) as Types.OAuthScopes[],
+    scope,
   });
 
   // Retrieve an access_token from your embedded app's server

--- a/src/generated/schemas.ts
+++ b/src/generated/schemas.ts
@@ -37,7 +37,7 @@ export const AuthenticateResponseSchema = z.object({
           'guilds.join',
           'guilds.members.read',
           'gdm.join',
-          'rpc',
+          '__NOT_AVAILABLE_FOR_USE__rpc',
           'rpc.notifications.read',
           'rpc.voice.read',
           'rpc.voice.write',

--- a/src/schema/types.ts
+++ b/src/schema/types.ts
@@ -71,7 +71,6 @@ export type LayoutModeTypeObject = typeof Common.LayoutModeTypeObject;
 
 export type OAuthScopes =
   | 'bot'
-  | 'rpc'
   | 'identify'
   | 'connections'
   | 'email'


### PR DESCRIPTION
* Since it's an enum, renamed the `rpc` one to `__NOT_AVAILABLE_FOR_USE__rpc` which should make it clear that it is not to be used.
* Removed `rpc` from types itself so that TS throws an error.
* Reworked the example code from type casting -> using a type signature so that the compiler gets angry if you use an invalid scope.

Cannot use the not available for use key:

<img width="1006" alt="Screenshot 2024-01-23 at 6 34 38 PM" src="https://github.com/discord/embedded-app-sdk/assets/10632/5a8cb7af-bca3-46ed-9151-8cc012a968b5">

rpc is an invalid scope too:

<img width="954" alt="Screenshot 2024-01-23 at 6 34 14 PM" src="https://github.com/discord/embedded-app-sdk/assets/10632/ff766dab-30ab-47ed-9da3-9d467a195045">

a made up key:

<img width="987" alt="Screenshot 2024-01-23 at 6 34 05 PM" src="https://github.com/discord/embedded-app-sdk/assets/10632/63d3ffb9-4846-45df-8b3b-28285becd669">
