### PR TITLE
Build as a part of the prepare step

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,11 +27,11 @@
     "test": "jest",
     "test:all": "pnpm test -r",
     "dev": "pnpm build --watch",
-    "build": "rollup --bundleConfigAsCjs -c rollup.config.mjs",
+    "build": "pnpm run prepare",
     "lint:ts": "tsc -b ./tsconfig-all.json",
     "lint": "pnpm eslint ./src",
     "lint:fix": "pnpm eslint --fix ./src ./examples/**/*.{ts,tsx}",
-    "prepare": "husky install"
+    "prepare": "husky install && rollup --bundleConfigAsCjs -c rollup.config.mjs"
   },
   "lint-staged": {
     "*.{ts,tsx}": "eslint --fix"


### PR DESCRIPTION
We want to build the package as a part of the "prepare" step, but we have a few constraints
- We want the prepare command to be package manager agnostic
- We can't use $npm_execpath because that's not supported by Windows
- We don't want to copy/paste the build steps into multiple places

This handles all our constraints at the cost of running husky-install in a few unnecessary places