### PR TITLE
Add shebang in example wrangler secret script

### DIFF
--- a/examples/sdk-playground/packages/server/handle-wrangler-secrets.sh
+++ b/examples/sdk-playground/packages/server/handle-wrangler-secrets.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 env=$1
 if [ -z "$env" ]

--- a/examples/sdk-playground/packages/server/handle-wrangler-secrets.sh
+++ b/examples/sdk-playground/packages/server/handle-wrangler-secrets.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 env=$1
 if [ -z "$env" ]


### PR DESCRIPTION
Without it, running `pnpm dev` fails:

```sh
packages/server dev$ ./handle-wrangler-secrets.sh dev local && wrangler dev src/index.ts --local --env dev
packages/server dev: setting wrangler env vars for env=dev mode=local
packages/server dev: ./handle-wrangler-secrets.sh: 25: Syntax error: redirection unexpected
packages/server dev: Failed
```