### PR TITLE
[Fix] Fix react-colyseus client

### DIFF
--- a/examples/react-colyseus/packages/client/package.json
+++ b/examples/react-colyseus/packages/client/package.json
@@ -20,6 +20,8 @@
     "@types/react": "^18.2.64",
     "@types/react-dom": "^18.2.7",
     "@vitejs/plugin-react": "^1.3.0",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.2.2",
     "vite": "^2.9.9"
   },
   "eslintConfig": {

--- a/examples/react-colyseus/packages/client/tsconfig.json
+++ b/examples/react-colyseus/packages/client/tsconfig.json
@@ -14,7 +14,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "experimentalDecorators": true
   },
   "include": ["."],
   "exclude": ["node_modules"]


### PR DESCRIPTION
The `client` package of the `react-colyseus` example was missing the `typescript` (and `ts-node`) package in the `package.json`. These are needed when running `pnpm build`, since that calls `tsc` and then `vite build`.

And because the `tsc` also builds the server code, the `experimentalDecorators` also needs to be added in the `tsconfig.json` of the client. The `server`'s `tsconfig.json` file already has it, but it is also needed in the client cause else you would get errors like:

```
../server/src/entities/State.ts:16:4 - error TS1240: Unable to resolve signature of property decorator when called as an expression.
  Argument of type 'undefined' is not assignable to parameter of type 'Object'.

16   @type('string')
      ~~~~~~~~~~~~~~
```

The client seems to build the server code since the client wants to include some of the server entities files.

So this all fixes it.

Kind Regards,
- Miniontoby

P.s. Really nice you guys finally released this SDK!