### PR TITLE
fix: support ssr and non-browser environments

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -107,6 +107,11 @@
         "import/export": "off",
         "import/named": "off"
       }
+    },
+    {
+      "files": "src/**/*.ts",
+      "plugins": ["ssr-friendly"],
+      "extends": ["plugin:ssr-friendly/recommended"]
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discord/embedded-app-sdk",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "@discord/embedded-app-sdk enables you to build rich, multiplayer experiences inside Discord.",
   "author": "Discord",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^5.1.0",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-ssr-friendly": "^1.3.0",
     "husky": "^7.0.2",
     "jest": "^27.3.1",
     "json-schema-to-zod": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       eslint-plugin-react-hooks:
         specifier: ^4.6.0
         version: 4.6.0(eslint@7.32.0)
+      eslint-plugin-ssr-friendly:
+        specifier: ^1.3.0
+        version: 1.3.0(eslint@7.32.0)
       husky:
         specifier: ^7.0.2
         version: 7.0.4
@@ -7371,6 +7374,15 @@ packages:
       semver: 6.3.1
       string.prototype.matchall: 4.0.10
     dev: false
+
+  /eslint-plugin-ssr-friendly@1.3.0(eslint@7.32.0):
+    resolution: {integrity: sha512-VOYl9OgK9mSVWxwl3pSTzNmBUMhPYjDGmxgyjSM9Agdve4GHjn0gAcCG/seg1taaW/aBWTkb7Aw4GIBsxVhL9Q==}
+    peerDependencies:
+      eslint: '>=0.8.0'
+    dependencies:
+      eslint: 7.32.0
+      globals: 13.24.0
+    dev: true
 
   /eslint-plugin-testing-library@5.11.1(eslint@8.55.0)(typescript@5.2.2):
     resolution: {integrity: sha512-5eX9e1Kc2PqVRed3taaLnAAqPZGEX75C+M/rXzUAI3wIg/ZxzUm1OVAwfe/O+vE+6YXOLetSe9g5GKD2ecXipw==}

--- a/src/utils/patchUrlMappings.ts
+++ b/src/utils/patchUrlMappings.ts
@@ -20,6 +20,9 @@ export function patchUrlMappings(
   mappings: Mapping[],
   {patchFetch = true, patchWebSocket = true, patchXhr = true, patchSrcAttributes = false}: PatchUrlMappingsConfig = {}
 ) {
+  // Bail out if we're not in a browser
+  if (typeof window === 'undefined') return;
+
   if (patchFetch) {
     const fetchImpl = window.fetch;
     // fetch is a duplex, but this is consistent


### PR DESCRIPTION
This PR patches usage of the global `window` variable to ensure the SDK can be used by non-browser environments, like [Remix](https://remix.run/) and [NextJS](https://nextjs.org/)