### PR TITLE
Fix activity starter xss

### DIFF
--- a/examples/discord-activity-starter/packages/client/src/main.ts
+++ b/examples/discord-activity-starter/packages/client/src/main.ts
@@ -88,7 +88,7 @@ async function appendVoiceChannelName() {
   // Update the UI with the name of the current voice channel
   const textTagString = `Activity Channel: "${activityChannelName}"`;
   const textTag = document.createElement('p');
-  textTag.innerHTML = textTagString;
+  textTag.textContent = textTagString;
   app.appendChild(textTag);
 }
 


### PR DESCRIPTION
`.innerHTML` is not safe for untrusted & unsanitized content like channel names, use `.textContent` instead.