### PR TITLE
Add back missing message event listener

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discord/embedded-app-sdk",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "@discord/embedded-app-sdk enables you to build rich, multiplayer experiences inside Discord.",
   "author": "Discord",
   "license": "MIT",

--- a/src/Discord.ts
+++ b/src/Discord.ts
@@ -95,6 +95,10 @@ export class DiscordSDK implements IDiscordSDK {
     this.clientId = clientId;
     this.configuration = configuration ?? getDefaultSdkConfiguration();
 
+    if (typeof window !== 'undefined') {
+      window.addEventListener('message', this.handleMessage);
+    }
+
     if (typeof window === 'undefined') {
       this.frameId = '';
       this.instanceId = '';


### PR DESCRIPTION
As a part of supporting SSR we removed a [very crucial line](https://github.com/discord/embedded-app-sdk/commit/2beca00fa2f07be5a6c6837a95513e24c9de5c8d#diff-63b380e466b8c60959f9ca00e5de37407382df7dd82b8aa4a9d7f896b0e43221L92)
This PR adds it back (with checks for SSR environments)