### PR TITLE
Add minimal test suite for DiscordSDK constructor

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "scripts": {
     "test": "jest",
+    "test:dev": "jest --watch",
     "test:all": "pnpm test -r",
     "dev": "pnpm build --watch",
     "build": "pnpm run prepare",

--- a/src/Discord.ts
+++ b/src/Discord.ts
@@ -12,7 +12,7 @@ import {ConsoleLevel, consoleLevels, wrapConsoleMethod} from './utils/console';
 import type {TSendCommand, TSendCommandPayload} from './schema/types';
 import {IDiscordSDK, MaybeZodObjectArray, SdkConfiguration} from './interface';
 
-enum Opcodes {
+export enum Opcodes {
   HANDSHAKE = 0,
   FRAME = 1,
   CLOSE = 2,

--- a/src/__tests__/discordSdk.test.ts
+++ b/src/__tests__/discordSdk.test.ts
@@ -85,6 +85,5 @@ describe('DiscordSDK', () => {
 
     // Verify "READY" event resolves
     await discordSdk.ready();
-    expect(true).toBe(true);
   });
 });

--- a/src/__tests__/discordSdk.test.ts
+++ b/src/__tests__/discordSdk.test.ts
@@ -1,0 +1,100 @@
+/**
+ * @jest-environment jsdom
+ */
+import {Opcodes} from '../Discord';
+import {DiscordSDK, Events, Platform} from '../index';
+import {DISPATCH} from '../schema/common';
+
+let windowSpy: jest.SpyInstance<Window & typeof globalThis, []>;
+
+beforeEach(() => {
+  windowSpy = jest.spyOn(window, 'window', 'get');
+});
+
+afterEach(() => {
+  windowSpy.mockRestore();
+});
+
+describe('DiscordSDK', () => {
+  it('Can be constructed and await a "ready" event', async () => {
+    const frame_id = '1234';
+    const instance_id = '2345';
+    const platform = Platform.DESKTOP;
+    const channel_id = '3456';
+    const guild_id = '4567';
+    const clientId = '1234567890';
+
+    Object.defineProperty(window, 'location', {
+      value: {
+        get pathname() {
+          return jest.fn();
+        },
+        replace: jest.fn(),
+        get search() {
+          return `?${new URLSearchParams({
+            frame_id,
+            instance_id,
+            platform,
+            channel_id,
+            guild_id,
+          }).toString()}`;
+        },
+      },
+    });
+    Object.defineProperty(window, 'parent', {
+      value: {
+        postMessage: jest.fn(),
+      },
+    });
+
+    const discordSdk = new DiscordSDK(clientId);
+
+    // Verify handshake
+    expect(window.parent.postMessage).toHaveBeenCalledWith(
+      [
+        Opcodes.HANDSHAKE,
+        {
+          client_id: clientId,
+          encoding: 'json',
+          frame_id: frame_id,
+          v: 1,
+        },
+      ],
+      '*'
+    );
+
+    // Verify instance variables
+    expect(discordSdk.clientId).toBe(clientId);
+    expect(discordSdk.instanceId).toBe(instance_id);
+    expect(discordSdk.platform).toBe(platform);
+    expect(discordSdk.channelId).toBe(channel_id);
+    expect(discordSdk.guildId).toBe(guild_id);
+
+    // Trigger "READY" event
+    dispatchEvent(
+      new MessageEvent('message', {
+        data: [
+          Opcodes.FRAME,
+          {
+            cmd: DISPATCH,
+            data: {
+              v: 1,
+              config: {
+                cdn_host: 'cdn.discordapp.com',
+                api_endpoint: '//canary.discord.com/api',
+                environment: 'production',
+              },
+            },
+            evt: Events.READY,
+            nonce: null,
+          },
+        ],
+        origin: 'https://discord.com',
+      })
+    );
+
+    // Verify "READY" event resolves
+    await discordSdk.ready();
+    expect(true).toBe(true);
+  });
+});

--- a/src/__tests__/discordSdk.test.ts
+++ b/src/__tests__/discordSdk.test.ts
@@ -5,16 +5,6 @@ import {Opcodes} from '../Discord';
 import {DiscordSDK, Events, Platform} from '../index';
 import {DISPATCH} from '../schema/common';
 
-let windowSpy: jest.SpyInstance<Window & typeof globalThis, []>;
-
-beforeEach(() => {
-  windowSpy = jest.spyOn(window, 'window', 'get');
-});
-
-afterEach(() => {
-  windowSpy.mockRestore();
-});
-
 describe('DiscordSDK', () => {
   it('Can be constructed and await a "ready" event', async () => {
     const frame_id = '1234';


### PR DESCRIPTION
This PR adds a minimal test for the DiscordSDK

It runs through constructing the SDK, verifying that the handshake is initiated, and that the sdk resolves being "READY" once a ready event is received.