### PR TITLE
chore: extend github action to auto-publish npm

### DIFF
--- a/.github/workflows/gihub-package-publish.yml
+++ b/.github/workflows/gihub-package-publish.yml
@@ -1,0 +1,29 @@
+name: Github Package Publish
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: main
+      - uses: pnpm/action-setup@v2
+        with:
+          version: latest
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install
+      - run: pnpm build
+      - uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ github.token }}
+          registry: https://npm.pkg.github.com

--- a/.github/workflows/npm-package-publish.yml
+++ b/.github/workflows/npm-package-publish.yml
@@ -1,4 +1,4 @@
-name: Package Publish
+name: NPM Package Publish
 
 on:
   release:
@@ -23,10 +23,6 @@ jobs:
           cache: pnpm
       - run: pnpm install
       - run: pnpm build
-      - uses: JS-DevTools/npm-publish@v1
-        with:
-          token: ${{ github.token }}
-          registry: https://npm.pkg.github.com
       - id: 'secrets'
         uses: 'google-github-actions/get-secretmanager-secrets@v1'
         with:

--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -1,4 +1,4 @@
-name: Github Publish
+name: Package Publish
 
 on:
   release:
@@ -7,6 +7,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     steps:
       - uses: actions/checkout@v3
         with:
@@ -24,3 +27,11 @@ jobs:
         with:
           token: ${{ github.token }}
           registry: https://npm.pkg.github.com
+      - id: 'secrets'
+        uses: 'google-github-actions/get-secretmanager-secrets@v1'
+        with:
+          secrets: |-
+            NPM_TOKEN:discord-app-city-prd/embedded-app-sdk-npm-token
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ steps.secrets.outputs.NPM_TOKEN }}


### PR DESCRIPTION
This PR extends the github action that previously published to the github-hosted npm package to also publish directly to npm