### PR TITLE
chore: bump versions of github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v3
-      - uses: pnpm/action-setup@v2
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
         with:
           version: latest
       - uses: actions/setup-node@v4


### PR DESCRIPTION
We are getting some funky errors on `pnpm install` specifically from dependabot PRs.  Before trying something else, I want to get on the latest versions of all our actions packages.