### PR TITLE
build: work around npm install path ssh bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
+      # This is required to work around https://github.com/npm/cli/issues/2610 
+      # for the case of dependabot PRs. 
+      - run: git config url."https://".insteadOf ssh://
       - uses: pnpm/action-setup@v3
         with:
           version: latest


### PR DESCRIPTION
Hopefully this fixes the issue with github install paths in package.json that's breaking dependabot PRs.  There is currently an issue where all PRs submitted by dependabot fail CI, due to `pnpm install` failing:

```
Scope: all 11 workspace projects
Lockfile is up to date, resolution step is skipped
Progress: resolved 1, reused 0, downloaded 0, added 0
Packages: +1080
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
Progress: resolved 1080, reused 0, downloaded 199, added 193
Progress: resolved 1080, reused 0, downloaded 454, added 45[7](https://github.com/discord/embedded-app-sdk/actions/runs/8682264272/job/23806513064?pr=131#step:5:8)
 ERROR  Command failed with exit code 128: /usr/bin/git clone git@github.com:uNetworking/uWebSockets.js.git /home/runner/setup-pnpm/node_modules/.bin/store/v3/tmp/_tmp_192[8](https://github.com/discord/embedded-app-sdk/actions/runs/8682264272/job/23806513064?pr=131#step:5:9)_d7038f93d0b9931c19e46a0377dcac29
Cloning into '/home/runner/setup-pnpm/node_modules/.bin/store/v3/tmp/_tmp_1[9](https://github.com/discord/embedded-app-sdk/actions/runs/8682264272/job/23806513064?pr=131#step:5:10)28_d7038f93d0b9931c19e46a0377dcac29'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.

pnpm: Command failed with exit code 128: /usr/bin/git clone git@github.com:uNetworking/uWebSockets.js.git /home/runner/setup-pnpm/node_modules/.bin/store/v3/tmp/_tmp_1928_d7038f93d0b9931c19e46a0377dcac29
Cloning into '/home/runner/setup-pnpm/node_modules/.bin/store/v3/tmp/_tmp_1928_d7038f93d0b9931c19e46a0377dcac29'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
    at makeError (/home/runner/setup-pnpm/node_modules/.pnpm/pnpm@8.15.7/node_modules/pnpm/dist/pnpm.cjs:24966:17)
    at handlePromise (/home/runner/setup-pnpm/node_modules/.pnpm/pnpm@8.15.7/node_modules/pnpm/dist/pnpm.cjs:25537:33)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async gitFetcher (/home/runner/setup-pnpm/node_modules/.pnpm/pnpm@8.15.7/node_modules/pnpm/dist/pnpm.cjs:[11](https://github.com/discord/embedded-app-sdk/actions/runs/8682264272/job/23806513064?pr=131#step:5:12)4675:11)
    at async fetcher (/home/runner/setup-pnpm/node_modules/.pnpm/pnpm@8.15.7/node_modules/pnpm/dist/pnpm.cjs:[12](https://github.com/discord/embedded-app-sdk/actions/runs/8682264272/job/23806513064?pr=131#step:5:13)7309:16)
    at async run (/home/runner/setup-pnpm/node_modules/.pnpm/pnpm@8.15.7/node_modules/pnpm/dist/pnpm.cjs:126774:23)
 ```

There are two factors here causing the issue.  This package, which is pulled in as a transitive dependency of an exmaple, is not published to github:
https://www.npmjs.com/package/uws

That triggers this bug in npm:
https://github.com/npm/cli/issues/2610

Which appears to create problems in github actions when there's no token/user available to do the clone.  