### PR TITLE
build: pin version of pnpm in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - run: git config url."https://".insteadOf ssh://
       - uses: pnpm/action-setup@v3
         with:
-          version: latest
+          version: 8.15.1
       - uses: actions/setup-node@v4
         with:
           node-version: 20


### PR DESCRIPTION
pnpm v9 was just released, and it does _not_ work with our current lock file. Pinning us in CI until we can sort it out. 