### PR TITLE
Feat: Add CommandInput and CommandResponse as types

### DIFF
--- a/examples/discord-activity-starter/packages/client/package.json
+++ b/examples/discord-activity-starter/packages/client/package.json
@@ -11,7 +11,6 @@
     "@discord/embedded-app-sdk": "workspace:@discord/embedded-app-sdk@*"
   },
   "devDependencies": {
-    "vite": "^5.2.9",
-    "type-fest": "^2.16.0"
+    "vite": "^5.2.9"
   }
 }

--- a/examples/discord-activity-starter/packages/client/src/main.ts
+++ b/examples/discord-activity-starter/packages/client/src/main.ts
@@ -1,8 +1,8 @@
+import type {CommandResponse} from '@discord/embedded-app-sdk';
 import './style.css';
 import {discordSdk} from './discordSdk';
-import type {AsyncReturnType} from 'type-fest';
 
-type Auth = AsyncReturnType<typeof discordSdk.commands.authenticate>;
+type Auth = CommandResponse<'authenticate'>;
 let auth: Auth;
 
 // Once setupDiscordSdk is complete, we can assert that "auth" is initialized
@@ -121,7 +121,7 @@ async function appendGuildAvatar() {
     guildImg.setAttribute(
       'src',
       // More info on image formatting here: https://discord.com/developers/docs/reference#image-formatting
-      `https://cdn.discordapp.com/icons/${currentGuild.id}/${currentGuild.icon}.webp?size=128`
+      `https://cdn.discordapp.com/icons/${currentGuild.id}/${currentGuild.icon}.webp?size=128`,
     );
     guildImg.setAttribute('width', '128px');
     guildImg.setAttribute('height', '128px');

--- a/examples/react-colyseus/packages/client/package.json
+++ b/examples/react-colyseus/packages/client/package.json
@@ -14,8 +14,7 @@
     "eslint": "^8.18.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "type-fest": "^4.8.3"
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.64",

--- a/examples/react-colyseus/packages/client/src/hooks/useAuthenticatedContext.tsx
+++ b/examples/react-colyseus/packages/client/src/hooks/useAuthenticatedContext.tsx
@@ -8,7 +8,7 @@ import {discordSdk} from '../discordSdk';
 import {LoadingScreen} from '../components/LoadingScreen';
 import {getUserAvatarUrl} from '../utils/getUserAvatarUrl';
 
-import type {IGuildsMembersRead, TAuthenticateResponse, TAuthenticatedContext} from '../types';
+import type {IGuildsMembersRead, TAuthenticatedContext} from '../types';
 import {getUserDisplayName} from '../utils/getUserDisplayName';
 
 const AuthenticatedContext = React.createContext<TAuthenticatedContext>({
@@ -102,7 +102,7 @@ function useAuthenticatedContextSetup() {
       const {access_token} = await response.json();
 
       // Authenticate with Discord client (using the access_token)
-      const newAuth: TAuthenticateResponse = await discordSdk.commands.authenticate({
+      const newAuth = await discordSdk.commands.authenticate({
         access_token,
       });
 

--- a/examples/react-colyseus/packages/client/src/types.tsx
+++ b/examples/react-colyseus/packages/client/src/types.tsx
@@ -1,14 +1,14 @@
-import type {AsyncReturnType} from 'type-fest';
-import {discordSdk} from './discordSdk';
+import type {CommandResponse} from '@discord/embedded-app-sdk';
 import {Client, Room} from 'colyseus.js';
 import {State} from '../../server/src/entities/State';
 
-export type TAuthenticateResponse = AsyncReturnType<typeof discordSdk.commands.authenticate>;
 export interface IColyseus {
   room: Room<State>;
   client: Client;
 }
-export type TAuthenticatedContext = TAuthenticateResponse & {guildMember: IGuildsMembersRead | null} & IColyseus;
+export type TAuthenticatedContext = CommandResponse<'authenticate'> & {
+  guildMember: IGuildsMembersRead | null;
+} & IColyseus;
 
 export interface IGuildsMembersRead {
   roles: string[];

--- a/examples/sdk-playground/packages/client/package.json
+++ b/examples/sdk-playground/packages/client/package.json
@@ -42,7 +42,6 @@
     "@types/react-dom": "^18.2.7",
     "@vitejs/plugin-react": "^1.3.0",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "type-fest": "^2.16.0",
     "typescript": "^5.2.2",
     "vite": "^5.2.9"
   },

--- a/examples/sdk-playground/packages/client/src/types.tsx
+++ b/examples/sdk-playground/packages/client/src/types.tsx
@@ -1,5 +1,5 @@
-import type {CommandResponseTypes} from '@discord/embedded-app-sdk';
-export type TAuthenticatedContext = CommandResponseTypes['authenticate'] & {guildMember: IGuildsMembersRead | null};
+import type {CommandResponse} from '@discord/embedded-app-sdk';
+export type TAuthenticatedContext = CommandResponse<'authenticate'> & {guildMember: IGuildsMembersRead | null};
 
 export interface IGuildsMembersRead {
   roles: string[];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,9 +161,6 @@ importers:
         specifier: workspace:@discord/embedded-app-sdk@*
         version: link:../../../..
     devDependencies:
-      type-fest:
-        specifier: ^2.16.0
-        version: 2.19.0
       vite:
         specifier: ^5.2.9
         version: 5.2.9(@types/node@20.12.7)
@@ -240,9 +237,6 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
-      type-fest:
-        specifier: ^4.8.3
-        version: 4.8.3
     devDependencies:
       '@types/react':
         specifier: ^18.2.64
@@ -389,9 +383,6 @@ importers:
       eslint-plugin-react-hooks:
         specifier: ^4.6.0
         version: 4.6.0(eslint@8.57.0)
-      type-fest:
-        specifier: ^2.16.0
-        version: 2.19.0
       typescript:
         specifier: ^5.2.2
         version: 5.2.2
@@ -8955,16 +8946,6 @@ packages:
     resolution: {integrity: sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==}
     engines: {node: '>=10'}
     dev: true
-
-  /type-fest@2.19.0:
-    resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
-    engines: {node: '>=12.20'}
-    dev: true
-
-  /type-fest@4.8.3:
-    resolution: {integrity: sha512-//BaTm14Q/gHBn09xlnKNqfI8t6bmdzx2DXYfPBNofN0WUybCEUDcbCWcTa0oF09lzLjZgPphXAsvRiMK0V6Bw==}
-    engines: {node: '>=16'}
-    dev: false
 
   /type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -56,6 +56,8 @@ export type CommandTypes = ReturnType<typeof commands>;
 export type CommandResponseTypes = {
   [Name in keyof CommandTypes]: Awaited<ReturnType<CommandTypes[Name]>>;
 };
+export type CommandResponse<K extends keyof CommandTypes> = Awaited<ReturnType<CommandTypes[K]>>;
 export type CommandInputTypes = {
   [Name in keyof CommandTypes]: Parameters<CommandTypes[Name]>;
 };
+export type CommandInput<K extends keyof CommandTypes> = Parameters<CommandTypes[K]>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import {DiscordSDK} from './Discord';
 import type {IDiscordSDK} from './interface';
 import type * as Types from './schema/types';
-import {CommandTypes, CommandResponseTypes, CommandInputTypes} from './commands';
+import {CommandTypes, CommandResponseTypes, CommandResponse, CommandInputTypes, CommandInput} from './commands';
 import {Events} from './schema/events';
 import * as Common from './schema/common';
 import * as Responses from './schema/responses';
@@ -31,4 +31,13 @@ export {
   patchUrlMappings,
   attemptRemap,
 };
-export type {IDiscordSDK, CommandTypes, CommandInputTypes, CommandResponseTypes, ISDKError, Types};
+export type {
+  IDiscordSDK,
+  CommandTypes,
+  CommandInput,
+  CommandInputTypes,
+  CommandResponse,
+  CommandResponseTypes,
+  ISDKError,
+  Types,
+};


### PR DESCRIPTION
The SDK exposed similar functionality already. This pattern leans on using generics to retrieve the object shape for command input and responses. The example below is contrived, better use-cases will be more complicated... but, this is an example of basic usage.

```ts
import type {CommandInput, CommandResponse} from '@discord/embedded-app-sdk';
import { discordSdk } from './discordSdk';

async function foo() {
  const getChannelInput: CommandInput<'getChannel'> = { channel_id: discordSdk.channelId };
  let getChannelReply: CommandResponse<'getChannel'>;
  getChannelReply = await discordSdk.commands.getChannel(getChannelInput);
}
```

As a part of this PR we're also removing the package `type-fest` which was previously used for `AsyncReturnType`. Turns out they're doing the same thing under the hood https://github.com/sindresorhus/type-fest/blob/main/source/async-return-type.d.ts#L23