### PR TITLE
chore: patch example usage of parsing default avatar

### DIFF
--- a/examples/react-colyseus/packages/client/src/utils/getUserAvatarUrl.tsx
+++ b/examples/react-colyseus/packages/client/src/utils/getUserAvatarUrl.tsx
@@ -22,6 +22,6 @@ export function getUserAvatarUrl({
     return `${cdn}/avatars/${user.id}/${user.avatar}.png?size=${size}`;
   }
 
-  const defaultAvatarIndex = Math.abs(Number(user.id) >> 22) % 6;
+  const defaultAvatarIndex = (BigInt(user.id ?? 0) >> 22n) % 6n;
   return `${cdn}/embed/avatars/${defaultAvatarIndex}.png?size=${size}`;
 }

--- a/examples/sdk-playground/packages/client/src/utils/getUserAvatarUrl.tsx
+++ b/examples/sdk-playground/packages/client/src/utils/getUserAvatarUrl.tsx
@@ -22,6 +22,6 @@ export function getUserAvatarUrl({
     return `${cdn}/avatars/${user.id}/${user.avatar}.png?size=${size}`;
   }
 
-  const defaultAvatarIndex = Math.abs(Number(user.id) >> 22) % 6;
+  const defaultAvatarIndex = (BigInt(user.id ?? 0) >> 22n) % 6n;
   return `${cdn}/embed/avatars/${defaultAvatarIndex}.png?size=${size}`;
 }


### PR DESCRIPTION
This one hurts to read. Snowflakes do not play well as numbers. The solution is to parse the user id into a BigInt. Tested on sdk-playground 🚀 