### PR TITLE
chore: use explicit renovate ignore paths

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,8 @@
     "config:recommended",
     ":disableDependencyDashboard",
     ":preserveSemverRanges"
+  ],
+  "ignorePaths": [
+    "**/node_modules/**"
   ]
 }


### PR DESCRIPTION
I think `/examples` is automatically ignored by default in renovate, so those underlying `package.json` files in examples aren't currently being scanned.  I believe this is part of the standard config:  https://docs.renovatebot.com/presets-default/#ignoremodulesandtests