### PR TITLE
fix: remove unavailable options from "setActivity" command

### DIFF
--- a/src/commands/setActivity.ts
+++ b/src/commands/setActivity.ts
@@ -11,9 +11,7 @@ export const SetActivity = Activity.pick({
   assets: true,
   party: true,
   secrets: true,
-  buttons: true,
   instance: true,
-  supported_platforms: true,
   type: true,
 })
   .extend({


### PR DESCRIPTION
Somehow with the upgrading of packages, we're now properly detecting that we're trying to "pick" from "Activity" some options that never existed in "Activity". This PR removes the never-available options `button` and `supported_platforms`