### PR TITLE
update auth examples with applications.commands scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ async function setup() {
     response_type: 'code',
     state: '',
     prompt: 'none',
-    scope: ['identify'],
+    scope: ['identify', 'applications.commands'],
   });
 
   // Retrieve an access_token from your application's server

--- a/examples/discord-activity-starter/packages/client/src/main.ts
+++ b/examples/discord-activity-starter/packages/client/src/main.ts
@@ -22,6 +22,10 @@ async function setupDiscordSdk() {
     prompt: 'none',
     // More info on scopes here: https://discord.com/developers/docs/topics/oauth2#shared-resources-oauth2-scopes
     scope: [
+      // Add the required applications.commands scope for user-installable apps.
+      // https://discord.com/developers/docs/tutorials/developing-a-user-installable-app#configuring-default-install-settings-adding-default-install-settings
+      'applications.commands',
+
       // "applications.builds.upload",
       // "applications.builds.read",
       // "applications.store.update",

--- a/examples/discord-activity-starter/packages/client/src/main.ts
+++ b/examples/discord-activity-starter/packages/client/src/main.ts
@@ -22,7 +22,7 @@ async function setupDiscordSdk() {
     prompt: 'none',
     // More info on scopes here: https://discord.com/developers/docs/topics/oauth2#shared-resources-oauth2-scopes
     scope: [
-      // Add the required applications.commands scope for user-installable apps.
+      // Activities will launch through app commands and interactions of user-installable apps.
       // https://discord.com/developers/docs/tutorials/developing-a-user-installable-app#configuring-default-install-settings-adding-default-install-settings
       'applications.commands',
 

--- a/examples/nested-messages/client/utils/initializeSdk.ts
+++ b/examples/nested-messages/client/utils/initializeSdk.ts
@@ -17,7 +17,7 @@ export async function initializeSdk(): Promise<DiscordSDK> {
     response_type: 'code',
     state: '',
     prompt: 'none',
-    scope: ['identify', 'rpc.activities.write', 'rpc.voice.read'],
+    scope: ['identify', 'applications.commands', 'rpc.activities.write', 'rpc.voice.read'],
   });
 
   // Retrieve an access_token from your embedded app's server

--- a/examples/react-colyseus/packages/client/src/hooks/useAuthenticatedContext.tsx
+++ b/examples/react-colyseus/packages/client/src/hooks/useAuthenticatedContext.tsx
@@ -67,6 +67,10 @@ function useAuthenticatedContextSetup() {
         prompt: 'none',
         // More info on scopes here: https://discord.com/developers/docs/topics/oauth2#shared-resources-oauth2-scopes
         scope: [
+          // Add the required applications.commands scope for user-installable apps.
+          // https://discord.com/developers/docs/tutorials/developing-a-user-installable-app#configuring-default-install-settings-adding-default-install-settings
+          'applications.commands',
+
           // "applications.builds.upload",
           // "applications.builds.read",
           // "applications.store.update",

--- a/examples/react-colyseus/packages/client/src/hooks/useAuthenticatedContext.tsx
+++ b/examples/react-colyseus/packages/client/src/hooks/useAuthenticatedContext.tsx
@@ -67,7 +67,7 @@ function useAuthenticatedContextSetup() {
         prompt: 'none',
         // More info on scopes here: https://discord.com/developers/docs/topics/oauth2#shared-resources-oauth2-scopes
         scope: [
-          // Add the required applications.commands scope for user-installable apps.
+          // Activities will launch through app commands and interactions of user-installable apps.
           // https://discord.com/developers/docs/tutorials/developing-a-user-installable-app#configuring-default-install-settings-adding-default-install-settings
           'applications.commands',
 

--- a/examples/sdk-playground/packages/client/src/actions/authActions.ts
+++ b/examples/sdk-playground/packages/client/src/actions/authActions.ts
@@ -20,7 +20,7 @@ export const start = async () => {
     prompt: 'none',
     // More info on scopes here: https://discord.com/developers/docs/topics/oauth2#shared-resources-oauth2-scopes
     scope: [
-      // Add the required applications.commands scope for user-installable apps.
+      // Activities will launch through app commands and interactions of user-installable apps.
       // https://discord.com/developers/docs/tutorials/developing-a-user-installable-app#configuring-default-install-settings-adding-default-install-settings
       'applications.commands',
 

--- a/examples/sdk-playground/packages/client/src/actions/authActions.ts
+++ b/examples/sdk-playground/packages/client/src/actions/authActions.ts
@@ -20,6 +20,10 @@ export const start = async () => {
     prompt: 'none',
     // More info on scopes here: https://discord.com/developers/docs/topics/oauth2#shared-resources-oauth2-scopes
     scope: [
+      // Add the required applications.commands scope for user-installable apps.
+      // https://discord.com/developers/docs/tutorials/developing-a-user-installable-app#configuring-default-install-settings-adding-default-install-settings
+      'applications.commands',
+
       // "applications.builds.upload",
       // "applications.builds.read",
       // "applications.store.update",


### PR DESCRIPTION
This is the first step of https://app.asana.com/0/1207125399187322/1207144243089950 . I'm updating the sdk-playground auth example and the other examples in this repo to add the `applications.commands` scope. When a user authorizes this scope for the user (rather than a guild), that will install the app to the user.

Additionally, we will have to do a migration that updates existing 1p / 3p-partner apps to
- be user installable and guild installable and
- have a primary entry point app command that launches an activity.

We can't update the requested auth scopes in the iframe code for the app developers though, so I'm going to point the 1p / 3p-partner developers to this example and ask them to make this one line change.

With this example, I'm making the following assumptions:
- Using the activity auth flow with the `applications.commands` scope, with no integration_type specified, installs to the user
- To install an activity app to a guild, admins will have to use the standard flow for adding apps to guilds, and that will not involve the iframe-initiated auth request (unless the iframe explicitly provides an integration_type for the guild-install in the auth request)