### PR TITLE
feat: add UPDATE_CURRENT_GUILD_MEMBER sdk hook and playground page

### DIFF
--- a/examples/discord-activity-starter/packages/client/src/main.ts
+++ b/examples/discord-activity-starter/packages/client/src/main.ts
@@ -37,7 +37,7 @@ async function setupDiscordSdk() {
       // "gdm.join",
       'guilds',
       // "guilds.join",
-      // "guilds.members.read",
+      'guilds.members.read',
       // "messages.read",
       // "relationships.read",
       // 'rpc.activities.write',

--- a/examples/sdk-playground/packages/client/src/App.tsx
+++ b/examples/sdk-playground/packages/client/src/App.tsx
@@ -8,6 +8,7 @@ import DesignSystemProvider from './components/DesignSystemProvider';
 import AvatarAndName from './pages/AvatarAndName';
 import CurrentGuild from './pages/CurrentGuild';
 import CurrentUser from './pages/CurrentUser';
+import CurrentGuildMember from './pages/CurrentGuildMember';
 import EncourageHardwareAcceleration from './pages/EncourageHardwareAcceleration';
 import Guilds from './pages/Guilds';
 import Home from './pages/Home';
@@ -162,6 +163,11 @@ const routes: Record<string, AppRoute> = {
     path: '/current-user',
     name: 'Current User',
     component: CurrentUser,
+  },
+  currentGuildMember: {
+    path: '/current-guild-member',
+    name: 'Current Guild Member',
+    component: CurrentGuildMember,
   },
   pipMode: {
     path: '/layout-mode',

--- a/examples/sdk-playground/packages/client/src/pages/CurrentGuildMember.tsx
+++ b/examples/sdk-playground/packages/client/src/pages/CurrentGuildMember.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import discordSdk from '../discordSdk';
+import ReactJsonView from '../components/ReactJsonView';
+import {useLocation} from 'react-router-dom';
+import {EventPayloadData} from '@discord/embedded-app-sdk';
+
+export default function CurrentGuildMember() {
+  const [currentGuildMember, setCurrentGuildMember] =
+    React.useState<EventPayloadData<'CURRENT_GUILD_MEMBER_UPDATE'> | null>(null);
+  const location = useLocation();
+
+  React.useEffect(() => {
+    const {channelId} = discordSdk;
+    if (!channelId) return;
+
+    const handleCurrentGuildMemberUpdate = (
+      currentGuildMemberEvent: EventPayloadData<'CURRENT_GUILD_MEMBER_UPDATE'>,
+    ) => {
+      setCurrentGuildMember(currentGuildMemberEvent);
+    };
+
+    const guildId = discordSdk.guildId;
+    if (guildId) {
+      discordSdk.subscribe('CURRENT_GUILD_MEMBER_UPDATE', handleCurrentGuildMemberUpdate, {
+        guild_id: guildId,
+      });
+    }
+
+    return () => {
+      if (guildId) {
+        discordSdk.unsubscribe('CURRENT_GUILD_MEMBER_UPDATE', handleCurrentGuildMemberUpdate, {
+          guild_id: guildId,
+        });
+      }
+    };
+  }, [location.search]);
+
+  return (
+    <div style={{padding: 32}}>
+      <div>
+        <h1>Event Subscription</h1>
+        <h2>CURRENT_GUILD_MEMBER_UPDATE</h2>
+        <br />
+        <br />
+        {currentGuildMember ? <ReactJsonView src={currentGuildMember} /> : null}
+      </div>
+    </div>
+  );
+}

--- a/src/schema/common.ts
+++ b/src/schema/common.ts
@@ -82,6 +82,21 @@ export const GuildMember = zod.object({
   mute: zod.boolean(),
 });
 
+export const GuildMemberRPC = zod.object({
+  user_id: zod.string(),
+  nick: zod.string().optional().nullable(),
+  guild_id: zod.string(),
+  avatar: zod.string().optional().nullable(),
+  avatar_decoration_data: zod
+    .object({
+      asset: zod.string(),
+      sku_id: zod.string().optional().nullable(),
+    })
+    .optional()
+    .nullable(),
+  color_string: zod.string().optional().nullable(),
+});
+
 export const Emoji = zod.object({
   id: zod.string(),
   name: zod.string().optional().nullable(),

--- a/src/schema/events.ts
+++ b/src/schema/events.ts
@@ -1,6 +1,6 @@
 import * as zod from 'zod';
 import {Orientation} from '../Constants';
-import {DISPATCH, GuildMember, UserVoiceState} from './common';
+import {DISPATCH, GuildMemberRPC, UserVoiceState} from './common';
 import {zodCoerceUnhandledValue} from '../utils/zodUtils';
 import {
   Entitlement,
@@ -203,7 +203,7 @@ export const EventSchema = {
   [Events.CURRENT_GUILD_MEMBER_UPDATE]: {
     payload: DispatchEventFrame.extend({
       evt: zod.literal(Events.CURRENT_GUILD_MEMBER_UPDATE),
-      data: GuildMember,
+      data: GuildMemberRPC,
     }),
     subscribeArgs: zod.object({
       guild_id: zod.string(),

--- a/src/schema/events.ts
+++ b/src/schema/events.ts
@@ -1,6 +1,6 @@
 import * as zod from 'zod';
 import {Orientation} from '../Constants';
-import {DISPATCH, UserVoiceState} from './common';
+import {DISPATCH, GuildMember, UserVoiceState} from './common';
 import {zodCoerceUnhandledValue} from '../utils/zodUtils';
 import {
   Entitlement,
@@ -23,6 +23,7 @@ export enum Events {
   ACTIVITY_LAYOUT_MODE_UPDATE = 'ACTIVITY_LAYOUT_MODE_UPDATE',
   ORIENTATION_UPDATE = 'ORIENTATION_UPDATE',
   CURRENT_USER_UPDATE = 'CURRENT_USER_UPDATE',
+  CURRENT_GUILD_MEMBER_UPDATE = 'CURRENT_GUILD_MEMBER_UPDATE',
   ENTITLEMENT_CREATE = 'ENTITLEMENT_CREATE',
   THERMAL_STATE_UPDATE = 'THERMAL_STATE_UPDATE',
   ACTIVITY_INSTANCE_PARTICIPANTS_UPDATE = 'ACTIVITY_INSTANCE_PARTICIPANTS_UPDATE',
@@ -197,6 +198,15 @@ export const EventSchema = {
     payload: DispatchEventFrame.extend({
       evt: zod.literal(Events.CURRENT_USER_UPDATE),
       data: User,
+    }),
+  },
+  [Events.CURRENT_GUILD_MEMBER_UPDATE]: {
+    payload: DispatchEventFrame.extend({
+      evt: zod.literal(Events.CURRENT_GUILD_MEMBER_UPDATE),
+      data: GuildMember,
+    }),
+    subscribeArgs: zod.object({
+      guild_id: zod.string(),
     }),
   },
   [Events.ENTITLEMENT_CREATE]: {


### PR DESCRIPTION
Adds support for activities to read guild member profiles' changes via RPC subscription. App side work still in progress