### PR TITLE
chore: rm sdk-playground "proxy" envs

### DIFF
--- a/examples/sdk-playground/example.env
+++ b/examples/sdk-playground/example.env
@@ -1,4 +1,4 @@
-# fill in the credentials for the desired environment (dev, dev-proxy, staging, prod)
+# fill in the credentials for the desired environment (dev, staging, prod)
 # copy this file to appropriate .env file, and then remove the changes
 # for example, for prod env
 #    `cp example.env .env.prod && git checkout example.env`

--- a/examples/sdk-playground/packages/client/package.json
+++ b/examples/sdk-playground/packages/client/package.json
@@ -6,9 +6,7 @@
   "scripts": {
     "test": "$npm_execpath run tsc",
     "dev": "vite --mode dev",
-    "dev-proxy": "vite --mode dev-proxy",
     "staging": "vite --mode staging",
-    "staging-proxy": "vite --mode staging-proxy",
     "build": "tsc && vite build",
     "build-staging": "tsc && vite build --mode staging",
     "preview": "vite preview",


### PR DESCRIPTION
they aren't really useful anymore, as they were intended for when there was no CSP exception for `https://discord.com/api`