### PR TITLE
fix(patchUrlMappings): recreate script elements when patching their src attribute

### DIFF
--- a/docs/local-sdk-development.md
+++ b/docs/local-sdk-development.md
@@ -11,4 +11,4 @@ To test changes to the SDK, locally, with either of these projects, you must do 
 
 1. From terminal, navigate to the root of either project's directory, (i.e. examples/discord-application-start or examples/sdk-playground)
 2. Start up the example's web server with `pnpm dev`.
-3. Start up the SDK's development pipeline with `pnpm dev`.
+3. In another terminal, start up the SDK's development pipeline with `pnpm dev` from the root of the repository.

--- a/docs/local-sdk-development.md
+++ b/docs/local-sdk-development.md
@@ -11,3 +11,4 @@ To test changes to the SDK, locally, with either of these projects, you must do 
 
 1. From terminal, navigate to the root of either project's directory, (i.e. examples/discord-application-start or examples/sdk-playground)
 2. Start up the example's web server with `pnpm dev`.
+3. Start up the SDK's development pipeline with `pnpm dev`.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig-base.json",
   "compilerOptions": {
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "rootDir": "src",
     // TODO: Enable this check. It is stricter.
     // https://app.asana.com/0/1202090529698493/1205406173366739/f


### PR DESCRIPTION
Currently, when a new `script` tag is created via an imported JavaScript package, we are changing the `src` attribute for that script tag when it goes through the normal `MutationObserver` flow. However, a refetch doesn't happen; `MutationObserver` only goes off when the HTML element is added, but never stops the outgoing request.

With this change, if the `MutationObserver` sees that it's modifying a `<script src=` attribute, it'll instead create a new `script` tag in the DOM next to the one it would have modified, and then destroy the original. Unfortunately this will still show the error from the request blocked by the CSP, but it will go off separately and make the new request with the second script tag as well, loading in the content.

**I'd be curious to collect thoughts on this solution.** It's obviously destructive to do this for things like `img` tags (since React for instance would break when it goes to rerender), but I'm hoping this will solve the problem for `script` tags.

Includes the change from https://github.com/discord/embedded-app-sdk/pull/239, since it was needed to fix my local test case as well.