### PR TITLE
Update package.json for react-colyseus example for Windows

### DIFF
--- a/examples/react-colyseus/packages/server/package.json
+++ b/examples/react-colyseus/packages/server/package.json
@@ -7,9 +7,9 @@
     "start": "npm-run-all build start:dev",
     "start:dev": "node ./dist/app.js",
     "start:prod": "NODE_ENV=production PORT=3000 node ./dist/app.js",
-    "dev": "nodemon --watch src -e ts,ejs --exec $npm_execpath start",
+    "dev": "nodemon --watch src -e ts,ejs --exec \"npm start\"",
     "build": "npm-run-all build:clean build:tsc",
-    "build:clean": "rimraf dist/*",
+    "build:clean": "rimraf dist",
     "build:tsc": "tsc",
     "debug:start": "npm-run-all build debug:start:prod",
     "debug:start:prod": "node --nolazy --inspect-brk=9229 ./dist/app.js"


### PR DESCRIPTION
Solves the same issue as in #57, but without creating an additional command.

I'm a little confused why the code there uses `npm_execpath` instead of just normal old `npm start`, if I'm missing something here I'd love to know. 

I've tested it on Windows, as well as Linux (Ubuntu) through WSL.