### PR TITLE
docs: add .proxy to /api/token call in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ async function setup() {
   });
 
   // Retrieve an access_token from your application's server
-  const response = await fetch('/api/token', {
+  const response = await fetch('/.proxy/api/token', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',


### PR DESCRIPTION
someone in ddevs pointed out that this README snippet doesn't work out of the box, and needs `/.proxy`