### PR TITLE
fix: prevent multiple remappings from applying the .proxy path twice

### DIFF
--- a/src/utils/__tests__/matchAndRewriteRoute.test.ts
+++ b/src/utils/__tests__/matchAndRewriteRoute.test.ts
@@ -61,6 +61,36 @@ describe('matchAndRewriteURL', () => {
       }
     });
 
+    it('matches base even if remapped twice', () => {
+      const TEST_CASES: Array<MatchAndRewriteURLInputs & {result: string}> = [
+        {
+          originalURL: new URL('https://discord.com'),
+          prefixHost: '123456789012345678.discordsays.com',
+          prefix: '/',
+          target: 'discord.com',
+          result: 'https://123456789012345678.discordsays.com/.proxy/',
+        },
+        {
+          originalURL: new URL('wss://discord.com'),
+          prefixHost: '123456789012345678.discordsays.com',
+          prefix: '/',
+          target: 'discord.com',
+          result: 'wss://123456789012345678.discordsays.com/.proxy/',
+        },
+      ];
+      for (const {result, ...rest} of TEST_CASES) {
+        const resultURL = matchAndRewriteURL(rest);
+        if (!(resultURL instanceof URL)) {
+          throw new Error('URL expected');
+        }
+        const result2URL = matchAndRewriteURL({
+          ...rest,
+          originalURL: resultURL,
+        });
+        expect(result2URL?.toString()).toEqual(result);
+      }
+    });
+
     it('matches non-base paths and doesnt mangle rest of path', () => {
       const TEST_CASES: Array<MatchAndRewriteURLInputs & {result: string}> = [
         {

--- a/src/utils/patchUrlMappings.ts
+++ b/src/utils/patchUrlMappings.ts
@@ -1,4 +1,4 @@
-import {absoluteURL, matchAndRewriteURL} from './url';
+import {absoluteURL, matchAndRewriteURL, PROXY_PREFIX} from './url';
 
 export interface Mapping {
   prefix: string;
@@ -15,8 +15,6 @@ interface PatchUrlMappingsConfig {
   patchXhr?: boolean;
   patchSrcAttributes?: boolean;
 }
-
-const PROXY_PREFIX = '/.proxy';
 
 export function patchUrlMappings(
   mappings: Mapping[],
@@ -162,6 +160,7 @@ export function attemptRemap({url, mappings}: RemapInput): URL {
   const newURL = new URL(url.toString());
   if (
     (newURL.hostname.includes('discordsays.com') || newURL.hostname.includes('discordsez.com')) &&
+    // Only apply proxy prefix once
     !newURL.pathname.startsWith(PROXY_PREFIX)
   ) {
     newURL.pathname = PROXY_PREFIX + newURL.pathname;

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,3 +1,5 @@
+export const PROXY_PREFIX = '/.proxy';
+
 /**
  * Creates a regular expression from a target string. The target string
  * may contain `{name}` tokens which will end up being translated to
@@ -48,8 +50,11 @@ export function matchAndRewriteURL({originalURL, prefix, prefixHost, target}: Ma
   // Append the original path
   newURL.pathname += newURL.pathname === '/' ? originalURL.pathname.slice(1) : originalURL.pathname;
   // prepend /.proxy/ to path if using discord activities proxy
-  if (newURL.hostname.includes('discordsays.com') || newURL.hostname.includes('discordsez.com')) {
-    newURL.pathname = '/.proxy' + newURL.pathname;
+  if (
+    (newURL.hostname.includes('discordsays.com') || newURL.hostname.includes('discordsez.com')) &&
+    !newURL.pathname.startsWith(PROXY_PREFIX)
+  ) {
+    newURL.pathname = PROXY_PREFIX + newURL.pathname;
   }
   // Remove the target's path from the new url path
   newURL.pathname = newURL.pathname.replace(targetURL.pathname, '');


### PR DESCRIPTION
We already do this in `attemptRemap` but we need to apply it in `matchAndRewriteURL` as well.

It's worth asking, why are we checking this twice? Why are we adding `/.proxy` in two places?
In case the original url has no matching urls to map to, we *still* want to inject the `/.proxy` path.