### PR TITLE
add location ID to SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discord/embedded-app-sdk",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "@discord/embedded-app-sdk enables you to build rich, multiplayer experiences inside Discord.",
   "author": "Discord",
   "license": "MIT",

--- a/src/Discord.ts
+++ b/src/Discord.ts
@@ -66,6 +66,7 @@ export class DiscordSDK implements IDiscordSDK {
   readonly platform: Platform;
   readonly guildId: string | null;
   readonly channelId: string | null;
+  readonly locationId: string | null;
   readonly sdkVersion: string = sdkVersion;
   readonly mobileAppVersion: string | null = null;
   readonly configuration: SdkConfiguration;
@@ -121,6 +122,7 @@ export class DiscordSDK implements IDiscordSDK {
       this.platform = Platform.DESKTOP;
       this.guildId = null;
       this.channelId = null;
+      this.locationId = null;
       return;
     }
 
@@ -151,6 +153,7 @@ export class DiscordSDK implements IDiscordSDK {
 
     this.guildId = urlParams.get('guild_id');
     this.channelId = urlParams.get('channel_id');
+    this.locationId = urlParams.get('location_id');
 
     this.mobileAppVersion = urlParams.get('mobile_app_version');
     // END Capture URL Query Params

--- a/src/mock.ts
+++ b/src/mock.ts
@@ -24,13 +24,15 @@ export class DiscordSDKMock implements IDiscordSDK {
   public commands: IDiscordSDK['commands'];
   readonly guildId: string | null;
   readonly channelId: string | null;
+  readonly locationId: string | null;
 
-  constructor(clientId: string, guildId: string | null, channelId: string | null) {
+  constructor(clientId: string, guildId: string | null, channelId: string | null, locationId: string | null) {
     this.clientId = clientId;
 
     this.commands = this._updateCommandMocks({});
     this.guildId = guildId;
     this.channelId = channelId;
+    this.locationId = locationId;
   }
 
   _updateCommandMocks(newCommands: Partial<IDiscordSDK['commands']>) {


### PR DESCRIPTION
The `GET /applications/<application_id>/activity-instances/<instance_id>` endpoint returns Activity instances with a location ID that does not necessarily refer to a channel. Discord passes the `location_id` query parameter to the iframe, so the Activity can compare that location ID with the location ID in the response from the `GET /applications/<application_id>/activity-instances/<instance_id>` endpoint.

This PR adds a `locationId` property to the SDK for reading that query parameter more easily.