### PR TITLE
Only receives window messages from the parent window (aka `this.source`)

### DIFF
--- a/src/Discord.ts
+++ b/src/Discord.ts
@@ -274,6 +274,7 @@ export class DiscordSDK implements IDiscordSDK {
    */
   private handleMessage = (event: MessageEvent) => {
     if (!ALLOWED_ORIGINS.has(event.origin)) return;
+    if (event.source !== this.source) return;
 
     const tuple = event.data;
     if (!Array.isArray(tuple)) {


### PR DESCRIPTION
Added a check to see if the event source (`event.source) is the source/parent (`this.source`) frame. This prevents DiscordSDK from picking from window messages from child iframes (iframes within the activity iframe).

If you were to run this code snippet within an iframe in a Discord activity's iframe, `DiscordSDK` would pick it up on the `handleMessage` function:

```js
(window.parent.opener ?? window.parent).postMessage("custom value", "*");
```

The result of executing the following script above in a (sandboxed) iframe within the activity iframe:

![image](https://github.com/user-attachments/assets/ce6a6856-6a3f-43db-9e2f-cc23c809276b)

This is something you wouldn't want to allow if you're displaying arbitrary iframes with user-generated content in your Discord activity, so I added a `if (event.source !== this.source) return;` under this code segement:

https://github.com/discord/embedded-app-sdk/blob/2cb879af80535b87d4a80cd98597f8ce3062f1cc/src/Discord.ts#L275-L276
