### PR TITLE
feat!: remove referrer_id from shareLink API

### DIFF
--- a/src/generated/schema.json
+++ b/src/generated/schema.json
@@ -214,7 +214,6 @@
     "request": {
       "type": "object",
       "properties": {
-        "referrer_id": {"type": "string", "maxLength": 64},
         "custom_id": {"type": "string", "maxLength": 64},
         "message": {"type": "string", "maxLength": 1000},
         "link_id": {"type": "string", "maxLength": 64}

--- a/src/generated/schemas.ts
+++ b/src/generated/schemas.ts
@@ -154,7 +154,6 @@ export type ShareInteractionResponse = zInfer<typeof ShareInteractionResponseSch
 
 // SHARE_LINK
 export const ShareLinkRequestSchema = z.object({
-  referrer_id: z.string().max(64).optional(),
   custom_id: z.string().max(64).optional(),
   message: z.string().max(1000),
   link_id: z.string().max(64).optional(),


### PR DESCRIPTION
another `npm run sync` based on recent changes.

Note: This is a breaking change! Consumers won't have any problems running the code if they're passing through a `referrer_id` but if they're relying on the types the compiler will yell at them.