### PR TITLE
feat: add new URL fields

### DIFF
--- a/src/commands/setActivity.ts
+++ b/src/commands/setActivity.ts
@@ -6,7 +6,9 @@ import {commandFactory} from '../utils/commandFactory';
 
 export const SetActivity = Activity.pick({
   state: true,
+  state_url: true,
   details: true,
+  details_url: true,
   timestamps: true,
   assets: true,
   party: true,

--- a/src/schema/common.ts
+++ b/src/schema/common.ts
@@ -154,7 +154,9 @@ export const Activity = zod.object({
     .nullable(),
   application_id: zod.string().optional().nullable(),
   details: zod.string().optional().nullable(),
+  details_url: zod.string().url().optional().nullable(),
   state: zod.string().optional().nullable(),
+  state_url: zod.string().url().optional().nullable(),
   emoji: Emoji.optional().nullable(),
   party: zod
     .object({
@@ -167,8 +169,10 @@ export const Activity = zod.object({
     .object({
       large_image: zod.string().nullable(),
       large_text: zod.string().nullable(),
+      large_url: zod.string().url().optional().nullable(),
       small_image: zod.string().nullable(),
       small_text: zod.string().nullable(),
+      small_url: zod.string().url().optional().nullable(),
     })
     .partial()
     .optional()


### PR DESCRIPTION
as part of a change that just went out today, we now support new fields for rich presence activities:

- `state_url` - URL that is linked to when clicking on the state text in the activity card
- `details_url` - URL that is linked to when clicking on the details text in the activity card
- `assets.large_url` - URL that is linked to when clicking on the large image in the activity card
- `assets.small_url` - URL that is linked to when clicking on the small image in the activity card

this PR adds support for those fields to the embedded app sdk

there is a docs pr to update documentation here: https://github.com/discord/discord-api-docs/pull/7674
