### PR TITLE
feat: add Quests commands + event 

### DIFF
--- a/src/generated/schema.json
+++ b/src/generated/schema.json
@@ -3,6 +3,7 @@
     "request": null,
     "response": {
       "type": "object",
+      "description": "Response for \"INITIATE_IMAGE_UPLOAD\" Command",
       "properties": {"image_url": {"type": "string"}},
       "required": ["image_url"],
       "additionalProperties": false
@@ -11,6 +12,7 @@
   "OPEN_SHARE_MOMENT_DIALOG": {
     "request": {
       "type": "object",
+      "description": "Request for \"OPEN_SHARE_MOMENT_DIALOG\" Command",
       "properties": {"mediaUrl": {"type": "string", "maxLength": 1024}},
       "required": ["mediaUrl"],
       "additionalProperties": false
@@ -20,11 +22,13 @@
   "AUTHENTICATE": {
     "request": {
       "type": "object",
+      "description": "Request for \"AUTHENTICATE\" Command",
       "properties": {"access_token": {"type": ["string", "null"]}},
       "additionalProperties": false
     },
     "response": {
       "type": "object",
+      "description": "Response for \"AUTHENTICATE\" Command",
       "properties": {
         "access_token": {"type": "string"},
         "user": {
@@ -90,7 +94,8 @@
               "payment_sources.country_code",
               "sdk.social_layer_presence",
               "sdk.social_layer",
-              "lobbies.write"
+              "lobbies.write",
+              "application_identities.write"
             ]
           }
         },
@@ -116,6 +121,7 @@
     "request": null,
     "response": {
       "type": "object",
+      "description": "Response for \"GET_ACTIVITY_INSTANCE_CONNECTED_PARTICIPANTS\" Command",
       "properties": {
         "participants": {
           "type": "array",
@@ -159,8 +165,18 @@
   "SHARE_INTERACTION": {
     "request": {
       "type": "object",
+      "description": "Request for \"SHARE_INTERACTION\" Command",
       "properties": {
         "command": {"type": "string"},
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {"name": {"type": "string"}, "value": {"type": "string"}},
+            "required": ["name", "value"],
+            "additionalProperties": false
+          }
+        },
         "content": {"type": "string", "maxLength": 2000},
         "require_launch_channel": {"type": "boolean"},
         "preview_image": {
@@ -198,13 +214,15 @@
             "required": ["type"],
             "additionalProperties": false
           }
-        }
+        },
+        "pid": {"type": "number"}
       },
       "required": ["command"],
       "additionalProperties": false
     },
     "response": {
       "type": "object",
+      "description": "Response for \"SHARE_INTERACTION\" Command",
       "properties": {"success": {"type": "boolean"}},
       "required": ["success"],
       "additionalProperties": false
@@ -213,6 +231,7 @@
   "SHARE_LINK": {
     "request": {
       "type": "object",
+      "description": "Request for \"SHARE_LINK\" Command",
       "properties": {
         "custom_id": {"type": "string", "maxLength": 64},
         "message": {"type": "string", "maxLength": 1000},
@@ -223,6 +242,7 @@
     },
     "response": {
       "type": "object",
+      "description": "Response for \"SHARE_LINK\" Command",
       "properties": {
         "success": {"type": "boolean"},
         "didCopyLink": {"type": "boolean"},
@@ -236,6 +256,7 @@
     "request": null,
     "response": {
       "type": "object",
+      "description": "Response for \"GET_RELATIONSHIPS\" Command",
       "properties": {
         "relationships": {
           "type": "array",
@@ -285,8 +306,11 @@
                       "name": {"type": "string"},
                       "url": {"type": ["string", "null"]},
                       "application_id": {"type": "string"},
+                      "status_display_type": {"type": "number"},
                       "state": {"type": "string"},
+                      "state_url": {"type": "string"},
                       "details": {"type": "string"},
+                      "details_url": {"type": "string"},
                       "emoji": {
                         "type": ["object", "null"],
                         "properties": {
@@ -302,8 +326,10 @@
                         "properties": {
                           "large_image": {"type": "string"},
                           "large_text": {"type": "string"},
+                          "large_url": {"type": "string"},
                           "small_image": {"type": "string"},
-                          "small_text": {"type": "string"}
+                          "small_text": {"type": "string"},
+                          "small_url": {"type": "string"}
                         },
                         "additionalProperties": false
                       },
@@ -356,6 +382,7 @@
   "INVITE_USER_EMBEDDED": {
     "request": {
       "type": "object",
+      "description": "Request for \"INVITE_USER_EMBEDDED\" Command",
       "properties": {"user_id": {"type": "string"}, "content": {"type": "string", "minLength": 0, "maxLength": 1024}},
       "required": ["user_id"],
       "additionalProperties": false
@@ -365,6 +392,7 @@
   "GET_USER": {
     "request": {
       "type": "object",
+      "description": "Request for \"GET_USER\" Command",
       "properties": {"id": {"type": "string", "maxLength": 64}},
       "required": ["id"],
       "additionalProperties": false
@@ -390,6 +418,42 @@
         "premium_type": {"type": ["number", "null"], "description": "Nitro premium type"}
       },
       "required": ["id", "username", "discriminator", "flags", "bot"],
+      "additionalProperties": false
+    }
+  },
+  "GET_QUEST_ENROLLMENT_STATUS": {
+    "request": {
+      "type": "object",
+      "description": "Request for \"GET_QUEST_ENROLLMENT_STATUS\" Command",
+      "properties": {"quest_id": {"type": "string"}},
+      "required": ["quest_id"],
+      "additionalProperties": false
+    },
+    "response": {
+      "type": "object",
+      "description": "Response for \"GET_QUEST_ENROLLMENT_STATUS\" Command",
+      "properties": {
+        "quest_id": {"type": "string"},
+        "is_enrolled": {"type": "boolean"},
+        "enrolled_at": {"type": ["string", "null"]}
+      },
+      "required": ["quest_id", "is_enrolled"],
+      "additionalProperties": false
+    }
+  },
+  "QUEST_START_TIMER": {
+    "request": {
+      "type": "object",
+      "description": "Request for \"QUEST_START_TIMER\" Command",
+      "properties": {"quest_id": {"type": "string"}},
+      "required": ["quest_id"],
+      "additionalProperties": false
+    },
+    "response": {
+      "type": "object",
+      "description": "Response for \"QUEST_START_TIMER\" Command",
+      "properties": {"success": {"type": "boolean"}},
+      "required": ["success"],
       "additionalProperties": false
     }
   }

--- a/src/generated/schemas.ts
+++ b/src/generated/schemas.ts
@@ -7,171 +7,106 @@ import {z, infer as zInfer} from 'zod';
 import {fallbackToDefault} from '../utils/zodUtils';
 
 // INITIATE_IMAGE_UPLOAD
-export const InitiateImageUploadResponseSchema = z.object({image_url: z.string()});
+export const InitiateImageUploadResponseSchema = z
+  .object({image_url: z.string()})
+  .describe('Response for "INITIATE_IMAGE_UPLOAD" Command');
 export type InitiateImageUploadResponse = zInfer<typeof InitiateImageUploadResponseSchema>;
 
 // OPEN_SHARE_MOMENT_DIALOG
-export const OpenShareMomentDialogRequestSchema = z.object({mediaUrl: z.string().max(1024)});
+export const OpenShareMomentDialogRequestSchema = z
+  .object({mediaUrl: z.string().max(1024)})
+  .describe('Request for "OPEN_SHARE_MOMENT_DIALOG" Command');
 export type OpenShareMomentDialogRequest = zInfer<typeof OpenShareMomentDialogRequestSchema>;
 
 // AUTHENTICATE
-export const AuthenticateRequestSchema = z.object({access_token: z.union([z.string(), z.null()]).optional()});
+export const AuthenticateRequestSchema = z
+  .object({access_token: z.union([z.string(), z.null()]).optional()})
+  .describe('Request for "AUTHENTICATE" Command');
 export type AuthenticateRequest = zInfer<typeof AuthenticateRequestSchema>;
-export const AuthenticateResponseSchema = z.object({
-  access_token: z.string(),
-  user: z.object({
-    username: z.string(),
-    discriminator: z.string(),
-    id: z.string(),
-    avatar: z.union([z.string(), z.null()]).optional(),
-    public_flags: z.number(),
-    global_name: z.union([z.string(), z.null()]).optional(),
-  }),
-  scopes: z.array(
-    fallbackToDefault(
-      z
-        .enum([
-          'identify',
-          'email',
-          'connections',
-          'guilds',
-          'guilds.join',
-          'guilds.members.read',
-          'guilds.channels.read',
-          'gdm.join',
-          'bot',
-          'rpc',
-          'rpc.notifications.read',
-          'rpc.voice.read',
-          'rpc.voice.write',
-          'rpc.video.read',
-          'rpc.video.write',
-          'rpc.screenshare.read',
-          'rpc.screenshare.write',
-          'rpc.activities.write',
-          'webhook.incoming',
-          'messages.read',
-          'applications.builds.upload',
-          'applications.builds.read',
-          'applications.commands',
-          'applications.commands.permissions.update',
-          'applications.commands.update',
-          'applications.store.update',
-          'applications.entitlements',
-          'activities.read',
-          'activities.write',
-          'activities.invites.write',
-          'relationships.read',
-          'relationships.write',
-          'voice',
-          'dm_channels.read',
-          'role_connections.write',
-          'presences.read',
-          'presences.write',
-          'openid',
-          'dm_channels.messages.read',
-          'dm_channels.messages.write',
-          'gateway.connect',
-          'account.global_name.update',
-          'payment_sources.country_code',
-          'sdk.social_layer_presence',
-          'sdk.social_layer',
-          'lobbies.write',
-        ])
-        .or(z.literal(-1))
-        .default(-1),
+export const AuthenticateResponseSchema = z
+  .object({
+    access_token: z.string(),
+    user: z.object({
+      username: z.string(),
+      discriminator: z.string(),
+      id: z.string(),
+      avatar: z.union([z.string(), z.null()]).optional(),
+      public_flags: z.number(),
+      global_name: z.union([z.string(), z.null()]).optional(),
+    }),
+    scopes: z.array(
+      fallbackToDefault(
+        z
+          .enum([
+            'identify',
+            'email',
+            'connections',
+            'guilds',
+            'guilds.join',
+            'guilds.members.read',
+            'guilds.channels.read',
+            'gdm.join',
+            'bot',
+            'rpc',
+            'rpc.notifications.read',
+            'rpc.voice.read',
+            'rpc.voice.write',
+            'rpc.video.read',
+            'rpc.video.write',
+            'rpc.screenshare.read',
+            'rpc.screenshare.write',
+            'rpc.activities.write',
+            'webhook.incoming',
+            'messages.read',
+            'applications.builds.upload',
+            'applications.builds.read',
+            'applications.commands',
+            'applications.commands.permissions.update',
+            'applications.commands.update',
+            'applications.store.update',
+            'applications.entitlements',
+            'activities.read',
+            'activities.write',
+            'activities.invites.write',
+            'relationships.read',
+            'relationships.write',
+            'voice',
+            'dm_channels.read',
+            'role_connections.write',
+            'presences.read',
+            'presences.write',
+            'openid',
+            'dm_channels.messages.read',
+            'dm_channels.messages.write',
+            'gateway.connect',
+            'account.global_name.update',
+            'payment_sources.country_code',
+            'sdk.social_layer_presence',
+            'sdk.social_layer',
+            'lobbies.write',
+            'application_identities.write',
+          ])
+          .or(z.literal(-1))
+          .default(-1),
+      ),
     ),
-  ),
-  expires: z.string(),
-  application: z.object({
-    description: z.string(),
-    icon: z.union([z.string(), z.null()]).optional(),
-    id: z.string(),
-    rpc_origins: z.array(z.string()).optional(),
-    name: z.string(),
-  }),
-});
+    expires: z.string(),
+    application: z.object({
+      description: z.string(),
+      icon: z.union([z.string(), z.null()]).optional(),
+      id: z.string(),
+      rpc_origins: z.array(z.string()).optional(),
+      name: z.string(),
+    }),
+  })
+  .describe('Response for "AUTHENTICATE" Command');
 export type AuthenticateResponse = zInfer<typeof AuthenticateResponseSchema>;
 
 // GET_ACTIVITY_INSTANCE_CONNECTED_PARTICIPANTS
-export const GetActivityInstanceConnectedParticipantsResponseSchema = z.object({
-  participants: z.array(
-    z.object({
-      id: z.string(),
-      username: z.string(),
-      global_name: z.union([z.string(), z.null()]).optional(),
-      discriminator: z.string(),
-      avatar: z.union([z.string(), z.null()]).optional(),
-      flags: z.number(),
-      bot: z.boolean(),
-      avatar_decoration_data: z
-        .union([
-          z.object({asset: z.string(), skuId: z.string().optional(), expiresAt: z.number().optional()}),
-          z.null(),
-        ])
-        .optional(),
-      premium_type: z.union([z.number(), z.null()]).optional(),
-      nickname: z.string().optional(),
-    }),
-  ),
-});
-export type GetActivityInstanceConnectedParticipantsResponse = zInfer<
-  typeof GetActivityInstanceConnectedParticipantsResponseSchema
->;
-
-// SHARE_INTERACTION
-export const ShareInteractionRequestSchema = z.object({
-  command: z.string(),
-  content: z.string().max(2000).optional(),
-  require_launch_channel: z.boolean().optional(),
-  preview_image: z.object({height: z.number(), url: z.string(), width: z.number()}).optional(),
-  components: z
-    .array(
+export const GetActivityInstanceConnectedParticipantsResponseSchema = z
+  .object({
+    participants: z.array(
       z.object({
-        type: z.literal(1),
-        components: z
-          .array(
-            z.object({
-              type: z.literal(2),
-              style: z.number().gte(1).lte(5),
-              label: z.string().max(80).optional(),
-              custom_id: z
-                .string()
-                .max(100)
-                .describe('Developer-defined identifier for the button; max 100 characters')
-                .optional(),
-            }),
-          )
-          .max(5)
-          .optional(),
-      }),
-    )
-    .optional(),
-});
-export type ShareInteractionRequest = zInfer<typeof ShareInteractionRequestSchema>;
-export const ShareInteractionResponseSchema = z.object({success: z.boolean()});
-export type ShareInteractionResponse = zInfer<typeof ShareInteractionResponseSchema>;
-
-// SHARE_LINK
-export const ShareLinkRequestSchema = z.object({
-  custom_id: z.string().max(64).optional(),
-  message: z.string().max(1000),
-  link_id: z.string().max(64).optional(),
-});
-export type ShareLinkRequest = zInfer<typeof ShareLinkRequestSchema>;
-export const ShareLinkResponseSchema = z.object({
-  success: z.boolean(),
-  didCopyLink: z.boolean(),
-  didSendMessage: z.boolean(),
-});
-export type ShareLinkResponse = zInfer<typeof ShareLinkResponseSchema>;
-
-// GET_RELATIONSHIPS
-export const GetRelationshipsResponseSchema = z.object({
-  relationships: z.array(
-    z.object({
-      type: z.number(),
-      user: z.object({
         id: z.string(),
         username: z.string(),
         global_name: z.union([z.string(), z.null()]).optional(),
@@ -186,76 +121,164 @@ export const GetRelationshipsResponseSchema = z.object({
           ])
           .optional(),
         premium_type: z.union([z.number(), z.null()]).optional(),
+        nickname: z.string().optional(),
       }),
-      presence: z
-        .object({
-          status: z.string(),
-          activity: z
-            .union([
+    ),
+  })
+  .describe('Response for "GET_ACTIVITY_INSTANCE_CONNECTED_PARTICIPANTS" Command');
+export type GetActivityInstanceConnectedParticipantsResponse = zInfer<
+  typeof GetActivityInstanceConnectedParticipantsResponseSchema
+>;
+
+// SHARE_INTERACTION
+export const ShareInteractionRequestSchema = z
+  .object({
+    command: z.string(),
+    options: z.array(z.object({name: z.string(), value: z.string()})).optional(),
+    content: z.string().max(2000).optional(),
+    require_launch_channel: z.boolean().optional(),
+    preview_image: z.object({height: z.number(), url: z.string(), width: z.number()}).optional(),
+    components: z
+      .array(
+        z.object({
+          type: z.literal(1),
+          components: z
+            .array(
               z.object({
-                session_id: z.string().optional(),
-                type: z.number().optional(),
-                name: z.string(),
-                url: z.union([z.string(), z.null()]).optional(),
-                application_id: z.string().optional(),
-                state: z.string().optional(),
-                details: z.string().optional(),
-                emoji: z
-                  .union([
-                    z.object({
-                      name: z.string(),
-                      id: z.union([z.string(), z.null()]).optional(),
-                      animated: z.union([z.boolean(), z.null()]).optional(),
-                    }),
-                    z.null(),
-                  ])
+                type: z.literal(2),
+                style: z.number().gte(1).lte(5),
+                label: z.string().max(80).optional(),
+                custom_id: z
+                  .string()
+                  .max(100)
+                  .describe('Developer-defined identifier for the button; max 100 characters')
                   .optional(),
-                assets: z
-                  .object({
-                    large_image: z.string().optional(),
-                    large_text: z.string().optional(),
-                    small_image: z.string().optional(),
-                    small_text: z.string().optional(),
-                  })
-                  .optional(),
-                timestamps: z.object({start: z.number().optional(), end: z.number().optional()}).optional(),
-                party: z
-                  .object({
-                    id: z.string().optional(),
-                    size: z.array(z.number()).min(2).max(2).optional(),
-                    privacy: z.number().optional(),
-                  })
-                  .optional(),
-                secrets: z.object({match: z.string().optional(), join: z.string().optional()}).optional(),
-                sync_id: z.string().optional(),
-                created_at: z.number().optional(),
-                instance: z.boolean().optional(),
-                flags: z.number().optional(),
-                metadata: z.object({}).optional(),
-                platform: z.string().optional(),
-                supported_platforms: z.array(z.string()).optional(),
-                buttons: z.array(z.string()).optional(),
-                hangStatus: z.string().optional(),
               }),
+            )
+            .max(5)
+            .optional(),
+        }),
+      )
+      .optional(),
+    pid: z.number().optional(),
+  })
+  .describe('Request for "SHARE_INTERACTION" Command');
+export type ShareInteractionRequest = zInfer<typeof ShareInteractionRequestSchema>;
+export const ShareInteractionResponseSchema = z
+  .object({success: z.boolean()})
+  .describe('Response for "SHARE_INTERACTION" Command');
+export type ShareInteractionResponse = zInfer<typeof ShareInteractionResponseSchema>;
+
+// SHARE_LINK
+export const ShareLinkRequestSchema = z
+  .object({
+    custom_id: z.string().max(64).optional(),
+    message: z.string().max(1000),
+    link_id: z.string().max(64).optional(),
+  })
+  .describe('Request for "SHARE_LINK" Command');
+export type ShareLinkRequest = zInfer<typeof ShareLinkRequestSchema>;
+export const ShareLinkResponseSchema = z
+  .object({success: z.boolean(), didCopyLink: z.boolean(), didSendMessage: z.boolean()})
+  .describe('Response for "SHARE_LINK" Command');
+export type ShareLinkResponse = zInfer<typeof ShareLinkResponseSchema>;
+
+// GET_RELATIONSHIPS
+export const GetRelationshipsResponseSchema = z
+  .object({
+    relationships: z.array(
+      z.object({
+        type: z.number(),
+        user: z.object({
+          id: z.string(),
+          username: z.string(),
+          global_name: z.union([z.string(), z.null()]).optional(),
+          discriminator: z.string(),
+          avatar: z.union([z.string(), z.null()]).optional(),
+          flags: z.number(),
+          bot: z.boolean(),
+          avatar_decoration_data: z
+            .union([
+              z.object({asset: z.string(), skuId: z.string().optional(), expiresAt: z.number().optional()}),
               z.null(),
             ])
             .optional(),
-        })
-        .optional(),
-    }),
-  ),
-});
+          premium_type: z.union([z.number(), z.null()]).optional(),
+        }),
+        presence: z
+          .object({
+            status: z.string(),
+            activity: z
+              .union([
+                z.object({
+                  session_id: z.string().optional(),
+                  type: z.number().optional(),
+                  name: z.string(),
+                  url: z.union([z.string(), z.null()]).optional(),
+                  application_id: z.string().optional(),
+                  status_display_type: z.number().optional(),
+                  state: z.string().optional(),
+                  state_url: z.string().optional(),
+                  details: z.string().optional(),
+                  details_url: z.string().optional(),
+                  emoji: z
+                    .union([
+                      z.object({
+                        name: z.string(),
+                        id: z.union([z.string(), z.null()]).optional(),
+                        animated: z.union([z.boolean(), z.null()]).optional(),
+                      }),
+                      z.null(),
+                    ])
+                    .optional(),
+                  assets: z
+                    .object({
+                      large_image: z.string().optional(),
+                      large_text: z.string().optional(),
+                      large_url: z.string().optional(),
+                      small_image: z.string().optional(),
+                      small_text: z.string().optional(),
+                      small_url: z.string().optional(),
+                    })
+                    .optional(),
+                  timestamps: z.object({start: z.number().optional(), end: z.number().optional()}).optional(),
+                  party: z
+                    .object({
+                      id: z.string().optional(),
+                      size: z.array(z.number()).min(2).max(2).optional(),
+                      privacy: z.number().optional(),
+                    })
+                    .optional(),
+                  secrets: z.object({match: z.string().optional(), join: z.string().optional()}).optional(),
+                  sync_id: z.string().optional(),
+                  created_at: z.number().optional(),
+                  instance: z.boolean().optional(),
+                  flags: z.number().optional(),
+                  metadata: z.object({}).optional(),
+                  platform: z.string().optional(),
+                  supported_platforms: z.array(z.string()).optional(),
+                  buttons: z.array(z.string()).optional(),
+                  hangStatus: z.string().optional(),
+                }),
+                z.null(),
+              ])
+              .optional(),
+          })
+          .optional(),
+      }),
+    ),
+  })
+  .describe('Response for "GET_RELATIONSHIPS" Command');
 export type GetRelationshipsResponse = zInfer<typeof GetRelationshipsResponseSchema>;
 
 // INVITE_USER_EMBEDDED
-export const InviteUserEmbeddedRequestSchema = z.object({
-  user_id: z.string(),
-  content: z.string().min(0).max(1024).optional(),
-});
+export const InviteUserEmbeddedRequestSchema = z
+  .object({user_id: z.string(), content: z.string().min(0).max(1024).optional()})
+  .describe('Request for "INVITE_USER_EMBEDDED" Command');
 export type InviteUserEmbeddedRequest = zInfer<typeof InviteUserEmbeddedRequestSchema>;
 
 // GET_USER
-export const GetUserRequestSchema = z.object({id: z.string().max(64)});
+export const GetUserRequestSchema = z.object({id: z.string().max(64)}).describe('Request for "GET_USER" Command');
 export type GetUserRequest = zInfer<typeof GetUserRequestSchema>;
 export const GetUserResponseSchema = z.union([
   z.object({
@@ -275,6 +298,26 @@ export const GetUserResponseSchema = z.union([
 ]);
 export type GetUserResponse = zInfer<typeof GetUserResponseSchema>;
 
+// GET_QUEST_ENROLLMENT_STATUS
+export const GetQuestEnrollmentStatusRequestSchema = z
+  .object({quest_id: z.string()})
+  .describe('Request for "GET_QUEST_ENROLLMENT_STATUS" Command');
+export type GetQuestEnrollmentStatusRequest = zInfer<typeof GetQuestEnrollmentStatusRequestSchema>;
+export const GetQuestEnrollmentStatusResponseSchema = z
+  .object({quest_id: z.string(), is_enrolled: z.boolean(), enrolled_at: z.union([z.string(), z.null()]).optional()})
+  .describe('Response for "GET_QUEST_ENROLLMENT_STATUS" Command');
+export type GetQuestEnrollmentStatusResponse = zInfer<typeof GetQuestEnrollmentStatusResponseSchema>;
+
+// QUEST_START_TIMER
+export const QuestStartTimerRequestSchema = z
+  .object({quest_id: z.string()})
+  .describe('Request for "QUEST_START_TIMER" Command');
+export type QuestStartTimerRequest = zInfer<typeof QuestStartTimerRequestSchema>;
+export const QuestStartTimerResponseSchema = z
+  .object({success: z.boolean()})
+  .describe('Response for "QUEST_START_TIMER" Command');
+export type QuestStartTimerResponse = zInfer<typeof QuestStartTimerResponseSchema>;
+
 /**
  * RPC Commands which support schemas.
  */
@@ -288,6 +331,8 @@ export enum Command {
   GET_RELATIONSHIPS = 'GET_RELATIONSHIPS',
   INVITE_USER_EMBEDDED = 'INVITE_USER_EMBEDDED',
   GET_USER = 'GET_USER',
+  GET_QUEST_ENROLLMENT_STATUS = 'GET_QUEST_ENROLLMENT_STATUS',
+  QUEST_START_TIMER = 'QUEST_START_TIMER',
 }
 
 const emptyResponseSchema = z.object({}).optional().nullable();
@@ -332,5 +377,13 @@ export const Schemas = {
   [Command.GET_USER]: {
     request: GetUserRequestSchema,
     response: GetUserResponseSchema,
+  },
+  [Command.GET_QUEST_ENROLLMENT_STATUS]: {
+    request: GetQuestEnrollmentStatusRequestSchema,
+    response: GetQuestEnrollmentStatusResponseSchema,
+  },
+  [Command.QUEST_START_TIMER]: {
+    request: QuestStartTimerRequestSchema,
+    response: QuestStartTimerResponseSchema,
   },
 } as const;

--- a/src/schema/events.ts
+++ b/src/schema/events.ts
@@ -29,6 +29,7 @@ export enum Events {
   ACTIVITY_INSTANCE_PARTICIPANTS_UPDATE = 'ACTIVITY_INSTANCE_PARTICIPANTS_UPDATE',
   RELATIONSHIP_UPDATE = 'RELATIONSHIP_UPDATE',
   ACTIVITY_JOIN = 'ACTIVITY_JOIN',
+  QUEST_ENROLLMENT_STATUS_UPDATE = 'QUEST_ENROLLMENT_STATUS_UPDATE',
 }
 
 export const DispatchEventFrame = ReceiveFrame.extend({
@@ -243,6 +244,16 @@ export const EventSchema = {
       data: zod.object({
         applicationId: zod.string(),
         secret: zod.string(),
+      }),
+    }),
+  },
+  [Events.QUEST_ENROLLMENT_STATUS_UPDATE]: {
+    payload: DispatchEventFrame.extend({
+      evt: zod.literal(Events.QUEST_ENROLLMENT_STATUS_UPDATE),
+      data: zod.object({
+        quest_id: zod.string(),
+        is_enrolled: zod.boolean(),
+        enrolled_at: zod.string().date(),
       }),
     }),
   },


### PR DESCRIPTION
- ran `npm run sync` 
  - automatically updated a number of generated commands 
   - added `GET_QUEST_ENROLLMENT` and `QUEST_START_TIMER` commands 
- manually added `QUEST_ENROLLMENT_STATUS_UPDATE` event 
