### PR TITLE
feat: automatic proxy token refresh

### DIFF
--- a/src/Discord.ts
+++ b/src/Discord.ts
@@ -185,7 +185,7 @@ export class DiscordSDK implements IDiscordSDK {
     this.handshake();
 
     if (this.configuration.autoRefreshProxyToken) {
-      this.tokenRefresh.monitor.enable((_tokenData) => this.refreshProxyToken());
+      this.tokenRefresh.monitor.enable(() => this.refreshProxyToken());
     }
   }
   close(code: RPCCloseCodes, message: string) {
@@ -371,7 +371,7 @@ export class DiscordSDK implements IDiscordSDK {
 
     const now = Date.now();
     if (now - this.tokenRefresh.lastRefreshTime < TOKEN_REFRESH_RATE_LIMIT_MS) {
-      return false;
+      return true;
     }
 
     this.tokenRefresh.promise = (async () => {

--- a/src/__tests__/discordSdk.test.ts
+++ b/src/__tests__/discordSdk.test.ts
@@ -160,28 +160,62 @@ describe('DiscordSDK', () => {
       expect(typeof discordSdk.refreshProxyToken).toBe('function');
     });
 
-    it('should rate limit successful refresh calls', async () => {
-      // Mock the command and fetch to succeed for testing rate limiting
+    it('rate limits subsequent refresh calls within the window and returns true (token is fresh)', async () => {
+      jest.useFakeTimers({now: 1_000_000});
+
       const originalCommand = discordSdk.commands.requestProxyTicketRefresh;
       discordSdk.commands.requestProxyTicketRefresh = jest.fn().mockResolvedValue({ticket: 'test'});
 
       const mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
       mockFetch.mockResolvedValue({ok: true} as Response);
 
-      // First call should succeed and update lastRefreshTime
       const result1 = await discordSdk.refreshProxyToken();
       expect(result1).toBe(true);
       expect(discordSdk.commands.requestProxyTicketRefresh).toHaveBeenCalledTimes(1);
 
-      // Clear the mock call count but keep the same implementation
       (discordSdk.commands.requestProxyTicketRefresh as jest.Mock).mockClear();
 
-      // Immediate second call should be rate limited (no new RPC call)
+      // Within the 1-minute rate-limit window, no RPC is sent and we still report the token as fresh
+      jest.advanceTimersByTime(30_000);
       const result2 = await discordSdk.refreshProxyToken();
-      expect(result2).toBe(false);
-      expect(discordSdk.commands.requestProxyTicketRefresh).toHaveBeenCalledTimes(0); // Rate limited
+      expect(result2).toBe(true);
+      expect(discordSdk.commands.requestProxyTicketRefresh).toHaveBeenCalledTimes(0);
 
-      // Restore original command
+      // After the window passes, refresh proceeds again
+      jest.advanceTimersByTime(31_000);
+      const result3 = await discordSdk.refreshProxyToken();
+      expect(result3).toBe(true);
+      expect(discordSdk.commands.requestProxyTicketRefresh).toHaveBeenCalledTimes(1);
+
+      discordSdk.commands.requestProxyTicketRefresh = originalCommand;
+      jest.useRealTimers();
+    });
+
+    it('coalesces concurrent refresh calls into a single in-flight request', async () => {
+      const originalCommand = discordSdk.commands.requestProxyTicketRefresh;
+
+      let resolveCommand: (value: {ticket: string}) => void = () => {};
+      const commandPromise = new Promise<{ticket: string}>((resolve) => {
+        resolveCommand = resolve;
+      });
+      discordSdk.commands.requestProxyTicketRefresh = jest.fn().mockReturnValue(commandPromise);
+
+      const mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
+      mockFetch.mockResolvedValue({ok: true} as Response);
+
+      const p1 = discordSdk.refreshProxyToken();
+      const p2 = discordSdk.refreshProxyToken();
+      const p3 = discordSdk.refreshProxyToken();
+
+      resolveCommand({ticket: 'test'});
+      const [r1, r2, r3] = await Promise.all([p1, p2, p3]);
+
+      expect(r1).toBe(true);
+      expect(r2).toBe(true);
+      expect(r3).toBe(true);
+      expect(discordSdk.commands.requestProxyTicketRefresh).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
       discordSdk.commands.requestProxyTicketRefresh = originalCommand;
     });
   });

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -13,6 +13,12 @@ export interface SdkConfiguration {
    * Setting this flag to true will disable this functionality
    */
   readonly disableConsoleLogOverride: boolean;
+  /**
+   * Enables automatic proxy token refresh to maintain long-running embedded activities.
+   * When enabled, the SDK will monitor proxy token expiration and automatically refresh
+   * tokens before they expire. Defaults to false for backwards compatibility.
+   */
+  readonly autoRefreshProxyToken?: boolean;
 }
 
 export type MaybeZodObjectArray<T extends EventArgs> =
@@ -45,4 +51,5 @@ export interface IDiscordSDK {
     ...unsubscribeArgs: MaybeZodObjectArray<(typeof EventSchema)[K]>
   ): Promise<unknown>;
   ready(): Promise<void>;
+  refreshProxyToken(): Promise<boolean>;
 }

--- a/src/mock.ts
+++ b/src/mock.ts
@@ -82,6 +82,11 @@ export class DiscordSDKMock implements IDiscordSDK {
   emitEvent<T>(event: string, data: T) {
     this.eventBus.emit(event, data);
   }
+
+  refreshProxyToken(): Promise<boolean> {
+    console.info('DiscordSDKMock: refreshProxyToken()');
+    return Promise.resolve(true);
+  }
 }
 /** Default return values for all discord SDK commands */
 export const commandsMockDefault: IDiscordSDK['commands'] = {

--- a/src/utils/ProxyTokenMonitor.ts
+++ b/src/utils/ProxyTokenMonitor.ts
@@ -1,0 +1,104 @@
+interface TokenData {
+  application_id: string;
+  user_id: string;
+  is_developer: boolean;
+  created_at: number;
+  expires_at: number;
+}
+
+export class ProxyTokenMonitor {
+  private refreshThreshold: number = 15 * 60; // 15 minutes before expiry (in seconds)
+  private timeoutId: number | null = null;
+  private enabled: boolean = false;
+  private onRefreshNeeded?: (tokenData: TokenData) => Promise<boolean>;
+
+  private parseTokenCookie(): TokenData | null {
+    if (typeof document === 'undefined') return null;
+
+    const cookies = document.cookie.split(';').reduce(
+      (acc, cookie) => {
+        const [key, value] = cookie.trim().split('=');
+        acc[key] = value;
+        return acc;
+      },
+      {} as Record<string, string>,
+    );
+
+    const token = cookies['discord_proxy_token'];
+    if (!token) return null;
+
+    try {
+      const [, payloadB64] = token.split('.');
+      if (!payloadB64) return null;
+
+      let payloadJson: string;
+      if (typeof Buffer !== 'undefined') {
+        payloadJson = Buffer.from(payloadB64, 'base64').toString('utf-8');
+      } else {
+        payloadJson = atob(payloadB64);
+      }
+
+      return JSON.parse(payloadJson) as TokenData;
+    } catch {
+      return null;
+    }
+  }
+
+  private calculateTimeUntilRefresh(tokenData: TokenData): number {
+    const now = Math.floor(Date.now() / 1000);
+    const refreshTime = tokenData.expires_at - this.refreshThreshold;
+    const msUntilRefresh = (refreshTime - now) * 1000;
+
+    // If token needs refresh now or very soon, refresh immediately
+    return Math.max(0, msUntilRefresh);
+  }
+
+  private scheduleRefresh(): void {
+    const tokenData = this.parseTokenCookie();
+    if (!tokenData || !this.enabled) return;
+
+    const msUntilRefresh = this.calculateTimeUntilRefresh(tokenData);
+
+    this.timeoutId = window.setTimeout(async () => {
+      if (!this.enabled) return;
+
+      // Get fresh token data in case it changed
+      const currentTokenData = this.parseTokenCookie();
+      if (!currentTokenData) return;
+
+      // Trigger refresh and wait for result
+      const refreshed = await this.onRefreshNeeded?.(currentTokenData);
+
+      // If refresh succeeded, schedule the next refresh with the new token
+      if (refreshed) {
+        // Small delay to ensure new token is available in cookies
+        setTimeout(() => this.scheduleRefresh(), 1000);
+      } else {
+        // If refresh failed, try again in 5 minutes
+        this.timeoutId = window.setTimeout(() => this.scheduleRefresh(), 5 * 60 * 1000);
+      }
+    }, msUntilRefresh);
+  }
+
+  public enable(onRefreshNeeded?: (tokenData: TokenData) => Promise<boolean>): void {
+    if (this.enabled || typeof window === 'undefined') return;
+
+    this.onRefreshNeeded = onRefreshNeeded;
+    this.enabled = true;
+
+    // Schedule the first refresh based on current token
+    this.scheduleRefresh();
+  }
+
+  public disable(): void {
+    if (!this.enabled) return;
+
+    this.enabled = false;
+    if (this.timeoutId && typeof window !== 'undefined') {
+      window.clearTimeout(this.timeoutId);
+      this.timeoutId = null;
+    }
+  }
+}
+
+export type {TokenData};

--- a/src/utils/ProxyTokenMonitor.ts
+++ b/src/utils/ProxyTokenMonitor.ts
@@ -6,37 +6,35 @@ interface TokenData {
   expires_at: number;
 }
 
+const REFRESH_THRESHOLD_SECONDS = 15 * 60;
+const RETRY_DELAY_MS = 5 * 60 * 1000;
+
 export class ProxyTokenMonitor {
-  private refreshThreshold: number = 15 * 60; // 15 minutes before expiry (in seconds)
   private timeoutId: number | null = null;
   private enabled: boolean = false;
-  private onRefreshNeeded?: (tokenData: TokenData) => Promise<boolean>;
+  private onRefreshNeeded?: () => Promise<unknown>;
 
   private parseTokenCookie(): TokenData | null {
     if (typeof document === 'undefined') return null;
 
-    const cookies = document.cookie.split(';').reduce(
-      (acc, cookie) => {
-        const [key, value] = cookie.trim().split('=');
-        acc[key] = value;
-        return acc;
-      },
-      {} as Record<string, string>,
-    );
-
-    const token = cookies['discord_proxy_token'];
+    let token: string | undefined;
+    for (const rawCookie of document.cookie.split(';')) {
+      const cookie = rawCookie.trim();
+      const eq = cookie.indexOf('=');
+      if (eq === -1) continue;
+      if (cookie.slice(0, eq) === 'discord_proxy_token') {
+        token = cookie.slice(eq + 1);
+        break;
+      }
+    }
     if (!token) return null;
 
     try {
-      const [, payloadB64] = token.split('.');
+      const [payloadB64] = token.split('.');
       if (!payloadB64) return null;
 
-      let payloadJson: string;
-      if (typeof Buffer !== 'undefined') {
-        payloadJson = Buffer.from(payloadB64, 'base64').toString('utf-8');
-      } else {
-        payloadJson = atob(payloadB64);
-      }
+      const payloadJson =
+        typeof Buffer !== 'undefined' ? Buffer.from(payloadB64, 'base64').toString('utf-8') : atob(payloadB64);
 
       return JSON.parse(payloadJson) as TokenData;
     } catch {
@@ -46,47 +44,42 @@ export class ProxyTokenMonitor {
 
   private calculateTimeUntilRefresh(tokenData: TokenData): number {
     const now = Math.floor(Date.now() / 1000);
-    const refreshTime = tokenData.expires_at - this.refreshThreshold;
-    const msUntilRefresh = (refreshTime - now) * 1000;
-
-    // If token needs refresh now or very soon, refresh immediately
-    return Math.max(0, msUntilRefresh);
+    const refreshTime = tokenData.expires_at - REFRESH_THRESHOLD_SECONDS;
+    return Math.max(0, (refreshTime - now) * 1000);
   }
 
   private scheduleRefresh(): void {
     const tokenData = this.parseTokenCookie();
     if (!tokenData || !this.enabled) return;
 
+    const oldExpiresAt = tokenData.expires_at;
     const msUntilRefresh = this.calculateTimeUntilRefresh(tokenData);
 
     this.timeoutId = window.setTimeout(async () => {
       if (!this.enabled) return;
 
-      // Get fresh token data in case it changed
-      const currentTokenData = this.parseTokenCookie();
-      if (!currentTokenData) return;
+      try {
+        await this.onRefreshNeeded?.();
+      } catch {
+        // fall through to expiry check; a thrown callback is treated as a failed refresh
+      }
+      if (!this.enabled) return;
 
-      // Trigger refresh and wait for result
-      const refreshed = await this.onRefreshNeeded?.(currentTokenData);
-
-      // If refresh succeeded, schedule the next refresh with the new token
-      if (refreshed) {
-        // Small delay to ensure new token is available in cookies
-        setTimeout(() => this.scheduleRefresh(), 1000);
+      const newTokenData = this.parseTokenCookie();
+      if (newTokenData && newTokenData.expires_at > oldExpiresAt) {
+        this.scheduleRefresh();
       } else {
-        // If refresh failed, try again in 5 minutes
-        this.timeoutId = window.setTimeout(() => this.scheduleRefresh(), 5 * 60 * 1000);
+        this.timeoutId = window.setTimeout(() => this.scheduleRefresh(), RETRY_DELAY_MS);
       }
     }, msUntilRefresh);
   }
 
-  public enable(onRefreshNeeded?: (tokenData: TokenData) => Promise<boolean>): void {
+  public enable(onRefreshNeeded: () => Promise<unknown>): void {
     if (this.enabled || typeof window === 'undefined') return;
 
     this.onRefreshNeeded = onRefreshNeeded;
     this.enabled = true;
 
-    // Schedule the first refresh based on current token
     this.scheduleRefresh();
   }
 
@@ -94,7 +87,7 @@ export class ProxyTokenMonitor {
     if (!this.enabled) return;
 
     this.enabled = false;
-    if (this.timeoutId && typeof window !== 'undefined') {
+    if (this.timeoutId != null && typeof window !== 'undefined') {
       window.clearTimeout(this.timeoutId);
       this.timeoutId = null;
     }

--- a/src/utils/__tests__/ProxyTokenMonitor.test.ts
+++ b/src/utils/__tests__/ProxyTokenMonitor.test.ts
@@ -1,0 +1,189 @@
+/**
+ * @jest-environment jsdom
+ */
+import {ProxyTokenMonitor, TokenData} from '../ProxyTokenMonitor';
+
+describe('ProxyTokenMonitor', () => {
+  let monitor: ProxyTokenMonitor;
+  let mockOnRefreshNeeded: jest.Mock;
+
+  beforeEach(() => {
+    monitor = new ProxyTokenMonitor();
+    mockOnRefreshNeeded = jest.fn().mockResolvedValue(true);
+    jest.clearAllTimers();
+    jest.useFakeTimers();
+
+    Object.defineProperty(document, 'cookie', {
+      writable: true,
+      value: '',
+    });
+  });
+
+  afterEach(() => {
+    monitor.disable();
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  const createValidToken = (expiresIn: number = 3600): string => {
+    const payload = {
+      application_id: '12345',
+      user_id: '67890',
+      is_developer: false,
+      created_at: Math.floor(Date.now() / 1000),
+      expires_at: Math.floor(Date.now() / 1000) + expiresIn,
+    };
+
+    const header = btoa(JSON.stringify({alg: 'HS256', typ: 'JWT'}));
+    const payloadB64 = btoa(JSON.stringify(payload));
+    const signature = 'mock-signature';
+
+    return `${header}.${payloadB64}.${signature}`;
+  };
+
+  describe('token parsing', () => {
+    it('should parse a valid JWT token from cookies', () => {
+      const token = createValidToken(3600);
+      document.cookie = `discord_proxy_token=${token}`;
+
+      const parseTokenCookie = (monitor as any).parseTokenCookie.bind(monitor);
+      const tokenData = parseTokenCookie();
+
+      expect(tokenData).toMatchObject({
+        application_id: '12345',
+        user_id: '67890',
+        is_developer: false,
+      });
+      expect(tokenData.expires_at).toBeGreaterThan(Math.floor(Date.now() / 1000));
+    });
+
+    it('should return null when no token cookie exists', () => {
+      document.cookie = 'other_cookie=value';
+
+      const parseTokenCookie = (monitor as any).parseTokenCookie.bind(monitor);
+      const tokenData = parseTokenCookie();
+
+      expect(tokenData).toBeNull();
+    });
+
+    it('should return null for malformed token', () => {
+      document.cookie = 'discord_proxy_token=invalid-token';
+
+      const parseTokenCookie = (monitor as any).parseTokenCookie.bind(monitor);
+      const tokenData = parseTokenCookie();
+
+      expect(tokenData).toBeNull();
+    });
+
+    it('should handle token with missing payload', () => {
+      document.cookie = 'discord_proxy_token=header..signature';
+
+      const parseTokenCookie = (monitor as any).parseTokenCookie.bind(monitor);
+      const tokenData = parseTokenCookie();
+
+      expect(tokenData).toBeNull();
+    });
+  });
+
+  describe('time calculation', () => {
+    it('should calculate immediate refresh for expiring token', () => {
+      const tokenData: TokenData = {
+        application_id: '12345',
+        user_id: '67890',
+        is_developer: false,
+        created_at: Math.floor(Date.now() / 1000),
+        expires_at: Math.floor(Date.now() / 1000) + 600, // 10 minutes
+      };
+
+      const calculateTimeUntilRefresh = (monitor as any).calculateTimeUntilRefresh.bind(monitor);
+      const msUntilRefresh = calculateTimeUntilRefresh(tokenData);
+
+      expect(msUntilRefresh).toBe(0); // Should refresh immediately
+    });
+
+    it('should calculate correct delay for future refresh', () => {
+      const tokenData: TokenData = {
+        application_id: '12345',
+        user_id: '67890',
+        is_developer: false,
+        created_at: Math.floor(Date.now() / 1000),
+        expires_at: Math.floor(Date.now() / 1000) + 3600, // 1 hour
+      };
+
+      const calculateTimeUntilRefresh = (monitor as any).calculateTimeUntilRefresh.bind(monitor);
+      const msUntilRefresh = calculateTimeUntilRefresh(tokenData);
+
+      // Should be 45 minutes (3600 - 900 seconds = 2700 seconds = 45 minutes)
+      expect(msUntilRefresh).toBe(45 * 60 * 1000);
+    });
+  });
+
+  describe('monitoring lifecycle', () => {
+    it('should enable monitoring and schedule timeout', () => {
+      const setTimeoutSpy = jest.spyOn(window, 'setTimeout');
+      const token = createValidToken(3600); // 1 hour
+      document.cookie = `discord_proxy_token=${token}`;
+
+      monitor.enable(mockOnRefreshNeeded);
+
+      expect(setTimeoutSpy).toHaveBeenCalled();
+    });
+
+    it('should disable monitoring and clear timeout', () => {
+      const clearTimeoutSpy = jest.spyOn(window, 'clearTimeout');
+      const token = createValidToken(3600); // 1 hour
+      document.cookie = `discord_proxy_token=${token}`;
+
+      monitor.enable(mockOnRefreshNeeded);
+      monitor.disable();
+
+      expect(clearTimeoutSpy).toHaveBeenCalled();
+    });
+
+    it('should not enable monitoring twice', () => {
+      const setTimeoutSpy = jest.spyOn(window, 'setTimeout');
+      const token = createValidToken(3600); // 1 hour
+      document.cookie = `discord_proxy_token=${token}`;
+
+      monitor.enable(mockOnRefreshNeeded);
+      monitor.enable(mockOnRefreshNeeded);
+
+      expect(setTimeoutSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should trigger refresh immediately when token needs refreshing', () => {
+      const setTimeoutSpy = jest.spyOn(window, 'setTimeout');
+      const token = createValidToken(600); // 10 minutes (needs refresh)
+      document.cookie = `discord_proxy_token=${token}`;
+
+      monitor.enable(mockOnRefreshNeeded);
+
+      // Should schedule with 0 delay (immediate)
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 0);
+    });
+
+    it('should schedule refresh at correct time for future expiry', () => {
+      const setTimeoutSpy = jest.spyOn(window, 'setTimeout');
+      const token = createValidToken(3600); // 1 hour
+      document.cookie = `discord_proxy_token=${token}`;
+
+      monitor.enable(mockOnRefreshNeeded);
+
+      // Should schedule for 45 minutes from now (60 - 15 minutes before expiry)
+      const expectedMs = 45 * 60 * 1000;
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expectedMs);
+    });
+
+    it('should call onRefreshNeeded when timeout fires', () => {
+      const token = createValidToken(600); // 10 minutes (needs refresh)
+      document.cookie = `discord_proxy_token=${token}`;
+
+      monitor.enable(mockOnRefreshNeeded);
+
+      // Trigger the timeout
+      jest.runOnlyPendingTimers();
+
+      expect(mockOnRefreshNeeded).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/utils/__tests__/ProxyTokenMonitor.test.ts
+++ b/src/utils/__tests__/ProxyTokenMonitor.test.ts
@@ -9,7 +9,7 @@ describe('ProxyTokenMonitor', () => {
 
   beforeEach(() => {
     monitor = new ProxyTokenMonitor();
-    mockOnRefreshNeeded = jest.fn().mockResolvedValue(true);
+    mockOnRefreshNeeded = jest.fn().mockResolvedValue(undefined);
     jest.clearAllTimers();
     jest.useFakeTimers();
 
@@ -25,24 +25,26 @@ describe('ProxyTokenMonitor', () => {
     jest.useRealTimers();
   });
 
-  const createValidToken = (expiresIn: number = 3600): string => {
-    const payload = {
+  // Token format produced by the proxy: base64(JSON payload).base64(signature)
+  // See discord_static/worker/routes/application-router-domain/proxyAuth.tsx
+  const createValidToken = (expiresIn: number = 3600, overrides: Partial<TokenData> = {}): string => {
+    const payload: TokenData = {
       application_id: '12345',
       user_id: '67890',
       is_developer: false,
       created_at: Math.floor(Date.now() / 1000),
       expires_at: Math.floor(Date.now() / 1000) + expiresIn,
+      ...overrides,
     };
 
-    const header = btoa(JSON.stringify({alg: 'HS256', typ: 'JWT'}));
     const payloadB64 = btoa(JSON.stringify(payload));
-    const signature = 'mock-signature';
+    const signature = btoa('mock-signature');
 
-    return `${header}.${payloadB64}.${signature}`;
+    return `${payloadB64}.${signature}`;
   };
 
   describe('token parsing', () => {
-    it('should parse a valid JWT token from cookies', () => {
+    it('parses a token from cookies', () => {
       const token = createValidToken(3600);
       document.cookie = `discord_proxy_token=${token}`;
 
@@ -57,82 +59,99 @@ describe('ProxyTokenMonitor', () => {
       expect(tokenData.expires_at).toBeGreaterThan(Math.floor(Date.now() / 1000));
     });
 
-    it('should return null when no token cookie exists', () => {
+    it('parses a token whose value contains base64 = padding', () => {
+      // Construct a payload sized so its base64 has = padding
+      const payload = {
+        application_id: '12345',
+        user_id: '67890',
+        is_developer: false,
+        created_at: 1000,
+        expires_at: 9999,
+      };
+      const payloadB64 = btoa(JSON.stringify(payload));
+      // Sanity: standard base64 of this JSON ends with '=' padding
+      expect(payloadB64.endsWith('=')).toBe(true);
+
+      const token = `${payloadB64}.${btoa('sig')}`;
+      document.cookie = `discord_proxy_token=${token}`;
+
+      const parseTokenCookie = (monitor as any).parseTokenCookie.bind(monitor);
+      const tokenData = parseTokenCookie();
+
+      expect(tokenData).toMatchObject(payload);
+    });
+
+    it('returns null when no token cookie exists', () => {
       document.cookie = 'other_cookie=value';
 
       const parseTokenCookie = (monitor as any).parseTokenCookie.bind(monitor);
-      const tokenData = parseTokenCookie();
-
-      expect(tokenData).toBeNull();
+      expect(parseTokenCookie()).toBeNull();
     });
 
-    it('should return null for malformed token', () => {
+    it('returns null for malformed token', () => {
       document.cookie = 'discord_proxy_token=invalid-token';
 
       const parseTokenCookie = (monitor as any).parseTokenCookie.bind(monitor);
-      const tokenData = parseTokenCookie();
-
-      expect(tokenData).toBeNull();
+      expect(parseTokenCookie()).toBeNull();
     });
 
-    it('should handle token with missing payload', () => {
-      document.cookie = 'discord_proxy_token=header..signature';
+    it('returns null when payload segment is empty', () => {
+      document.cookie = 'discord_proxy_token=.signature';
 
       const parseTokenCookie = (monitor as any).parseTokenCookie.bind(monitor);
-      const tokenData = parseTokenCookie();
+      expect(parseTokenCookie()).toBeNull();
+    });
 
-      expect(tokenData).toBeNull();
+    it('parses the correct cookie when other cookies are present', () => {
+      const token = createValidToken(3600);
+      document.cookie = `other=foo; discord_proxy_token=${token}; another=bar`;
+
+      const parseTokenCookie = (monitor as any).parseTokenCookie.bind(monitor);
+      expect(parseTokenCookie()).toMatchObject({application_id: '12345'});
     });
   });
 
   describe('time calculation', () => {
-    it('should calculate immediate refresh for expiring token', () => {
+    it('returns 0 for tokens already inside the refresh window', () => {
       const tokenData: TokenData = {
         application_id: '12345',
         user_id: '67890',
         is_developer: false,
         created_at: Math.floor(Date.now() / 1000),
-        expires_at: Math.floor(Date.now() / 1000) + 600, // 10 minutes
+        expires_at: Math.floor(Date.now() / 1000) + 600,
       };
 
       const calculateTimeUntilRefresh = (monitor as any).calculateTimeUntilRefresh.bind(monitor);
-      const msUntilRefresh = calculateTimeUntilRefresh(tokenData);
-
-      expect(msUntilRefresh).toBe(0); // Should refresh immediately
+      expect(calculateTimeUntilRefresh(tokenData)).toBe(0);
     });
 
-    it('should calculate correct delay for future refresh', () => {
+    it('schedules 15 minutes before expiry', () => {
       const tokenData: TokenData = {
         application_id: '12345',
         user_id: '67890',
         is_developer: false,
         created_at: Math.floor(Date.now() / 1000),
-        expires_at: Math.floor(Date.now() / 1000) + 3600, // 1 hour
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
       };
 
       const calculateTimeUntilRefresh = (monitor as any).calculateTimeUntilRefresh.bind(monitor);
-      const msUntilRefresh = calculateTimeUntilRefresh(tokenData);
-
-      // Should be 45 minutes (3600 - 900 seconds = 2700 seconds = 45 minutes)
-      expect(msUntilRefresh).toBe(45 * 60 * 1000);
+      expect(calculateTimeUntilRefresh(tokenData)).toBe(45 * 60 * 1000);
     });
   });
 
   describe('monitoring lifecycle', () => {
-    it('should enable monitoring and schedule timeout', () => {
+    it('enables monitoring and schedules a timeout', () => {
       const setTimeoutSpy = jest.spyOn(window, 'setTimeout');
-      const token = createValidToken(3600); // 1 hour
-      document.cookie = `discord_proxy_token=${token}`;
+      document.cookie = `discord_proxy_token=${createValidToken(3600)}`;
 
       monitor.enable(mockOnRefreshNeeded);
 
       expect(setTimeoutSpy).toHaveBeenCalled();
     });
 
-    it('should disable monitoring and clear timeout', () => {
+    it('clears the scheduled timeout on disable', () => {
       const clearTimeoutSpy = jest.spyOn(window, 'clearTimeout');
-      const token = createValidToken(3600); // 1 hour
-      document.cookie = `discord_proxy_token=${token}`;
+      document.cookie = `discord_proxy_token=${createValidToken(3600)}`;
 
       monitor.enable(mockOnRefreshNeeded);
       monitor.disable();
@@ -140,10 +159,9 @@ describe('ProxyTokenMonitor', () => {
       expect(clearTimeoutSpy).toHaveBeenCalled();
     });
 
-    it('should not enable monitoring twice', () => {
+    it('does not enable monitoring twice', () => {
       const setTimeoutSpy = jest.spyOn(window, 'setTimeout');
-      const token = createValidToken(3600); // 1 hour
-      document.cookie = `discord_proxy_token=${token}`;
+      document.cookie = `discord_proxy_token=${createValidToken(3600)}`;
 
       monitor.enable(mockOnRefreshNeeded);
       monitor.enable(mockOnRefreshNeeded);
@@ -151,39 +169,77 @@ describe('ProxyTokenMonitor', () => {
       expect(setTimeoutSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('should trigger refresh immediately when token needs refreshing', () => {
+    it('triggers refresh immediately when token is already inside the threshold', () => {
       const setTimeoutSpy = jest.spyOn(window, 'setTimeout');
-      const token = createValidToken(600); // 10 minutes (needs refresh)
-      document.cookie = `discord_proxy_token=${token}`;
+      document.cookie = `discord_proxy_token=${createValidToken(600)}`;
 
       monitor.enable(mockOnRefreshNeeded);
 
-      // Should schedule with 0 delay (immediate)
       expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 0);
     });
 
-    it('should schedule refresh at correct time for future expiry', () => {
+    it('schedules refresh 15 minutes before future expiry', () => {
       const setTimeoutSpy = jest.spyOn(window, 'setTimeout');
-      const token = createValidToken(3600); // 1 hour
-      document.cookie = `discord_proxy_token=${token}`;
+      document.cookie = `discord_proxy_token=${createValidToken(3600)}`;
 
       monitor.enable(mockOnRefreshNeeded);
 
-      // Should schedule for 45 minutes from now (60 - 15 minutes before expiry)
-      const expectedMs = 45 * 60 * 1000;
-      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expectedMs);
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 45 * 60 * 1000);
     });
 
-    it('should call onRefreshNeeded when timeout fires', () => {
-      const token = createValidToken(600); // 10 minutes (needs refresh)
-      document.cookie = `discord_proxy_token=${token}`;
+    it('calls onRefreshNeeded when the scheduled timeout fires', async () => {
+      document.cookie = `discord_proxy_token=${createValidToken(600)}`;
 
       monitor.enable(mockOnRefreshNeeded);
-
-      // Trigger the timeout
-      jest.runOnlyPendingTimers();
+      await jest.runOnlyPendingTimersAsync();
 
       expect(mockOnRefreshNeeded).toHaveBeenCalled();
+    });
+
+    it('reschedules from the new token when expires_at advances after the callback', async () => {
+      const setTimeoutSpy = jest.spyOn(window, 'setTimeout');
+      document.cookie = `discord_proxy_token=${createValidToken(600)}`;
+
+      mockOnRefreshNeeded.mockImplementation(() => {
+        document.cookie = `discord_proxy_token=${createValidToken(3600)}`;
+        return Promise.resolve();
+      });
+
+      monitor.enable(mockOnRefreshNeeded);
+      setTimeoutSpy.mockClear();
+      await jest.runOnlyPendingTimersAsync();
+
+      // After successful refresh, the next setTimeout uses the new token's expiry: 45 minutes
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 45 * 60 * 1000);
+    });
+
+    it('retries in 5 minutes when the cookie did not advance', async () => {
+      const setTimeoutSpy = jest.spyOn(window, 'setTimeout');
+      document.cookie = `discord_proxy_token=${createValidToken(600)}`;
+
+      // Callback does nothing -> cookie unchanged
+      monitor.enable(mockOnRefreshNeeded);
+      setTimeoutSpy.mockClear();
+      await jest.runOnlyPendingTimersAsync();
+
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 5 * 60 * 1000);
+    });
+
+    it('does not reschedule after disable() during an in-flight callback', async () => {
+      const setTimeoutSpy = jest.spyOn(window, 'setTimeout');
+      document.cookie = `discord_proxy_token=${createValidToken(600)}`;
+
+      mockOnRefreshNeeded.mockImplementation(() => {
+        monitor.disable();
+        document.cookie = `discord_proxy_token=${createValidToken(3600)}`;
+        return Promise.resolve();
+      });
+
+      monitor.enable(mockOnRefreshNeeded);
+      setTimeoutSpy.mockClear();
+      await jest.runOnlyPendingTimersAsync();
+
+      expect(setTimeoutSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/utils/getDefaultSdkConfiguration.ts
+++ b/src/utils/getDefaultSdkConfiguration.ts
@@ -3,5 +3,6 @@ import {SdkConfiguration} from '../interface';
 export default function getDefaultSdkConfiguration(): SdkConfiguration {
   return {
     disableConsoleLogOverride: false,
+    autoRefreshProxyToken: false,
   };
 }


### PR DESCRIPTION
- adds `REQUEST_PROXY_TICKET_REFRESH` command 
- adds `ProxyTokenMonitor` class to monitor when a token needs refreshing 
- when enabled via configuration, performs automatic refreshing of token by 
  - calls command `requestProxyTicketRefresh` for new ticket 
  - exchanges ticket for token with proxy 
